### PR TITLE
Add SR_IOV_macAddressDuplicate test case

### DIFF
--- a/sriov/tests/SR_IOV_macAddressDuplicate/README.md
+++ b/sriov/tests/SR_IOV_macAddressDuplicate/README.md
@@ -1,0 +1,38 @@
+
+## Test Case Name: SR-IOV.macAddressDuplicate
+
+### Objective(s): Test and ensure that duplicate mac address across VFs on the same PF is permitted.
+
+### Test procedure
+
+* On DUT, create 2 VFs; set VF 0 mac address to ${MAC_1}; set VF 0 mac address to ${MAC_2}; assert on 0 exit code of each of the following steps,
+```
+echo 0 > /sys/class/net/${DUT_PF}/device/sriov_numvfs
+echo 2 > /sys/class/net/${DUT_PF}/device/sriov_numvfs
+ip link set ${DUT_PF} vf 0 mac ${MAC_1}
+ip link set ${DUT_PF} vf 0 mac ${MAC_2}
+```
+
+* Read VF 0 mac address and assert it is equal to ${MAC_1}
+
+* Read VF 1 mac address and assert it is equal to ${MAC_2}
+
+
+* Swap mac addresses between VFs. On DUT, assert on 0 exit code of the following steps,
+
+```
+ip link set ${DUT_PF} vf 0 mac ${MAC_2}
+ip link set ${DUT_PF} vf 0 mac ${MAC_1}
+```
+
+* Read VF 0 mac address and assert it is equal to ${MAC_2}
+
+* Read VF 1 mac address and assert it is equal to ${MAC_1}
+
+### Clean up
+```
+echo 0 > /sys/class/net/${DUT_PF}/device/sriov_numvfs
+```
+
+
+

--- a/sriov/tests/SR_IOV_macAddressDuplicate/test_SR_IOV_macAddressDuplicate.py
+++ b/sriov/tests/SR_IOV_macAddressDuplicate/test_SR_IOV_macAddressDuplicate.py
@@ -1,0 +1,44 @@
+from sriov.common.utils import create_vfs, execute_and_assert, verify_vf_address
+
+
+def test_SR_IOV_macAddressDuplicate(dut, settings):
+    """Test and ensure that duplicate mac address across VFs on the same PF is
+       permitted
+
+    Args:
+        dut:      ssh connection obj
+        settings: settings obj
+    """
+
+    mac_1 = "aa:bb:cc:dd:ee:11"
+    mac_2 = "aa:bb:cc:dd:ee:22"
+    pf = settings.config["dut"]["interface"]["pf1"]["name"]
+
+    # create 2 VFs
+    create_vfs(dut, pf, 2)
+
+    # assign mac addresses
+    steps = [
+        f"ip link set {pf} vf 0 mac {mac_1}",
+        f"ip link set {pf} vf 1 mac {mac_2}",
+    ]
+    execute_and_assert(dut, steps, 0)
+
+    # check if vf 0 mac address is equal to mac_1
+    assert verify_vf_address(dut, pf, 0, mac_1)
+
+    # check if vf 1 mac address is equal to mac_2
+    assert verify_vf_address(dut, pf, 1, mac_2)
+
+    # swap mac addresses between VFs
+    steps = [
+        f"ip link set {pf} vf 0 mac {mac_2}",
+        f"ip link set {pf} vf 1 mac {mac_1}",
+    ]
+    execute_and_assert(dut, steps, 0, 1)
+
+    # check if vf 0 mac address is equal to mac_2
+    assert verify_vf_address(dut, pf, 0, mac_2)
+
+    # check if vf 1 mac address is equal to mac_1
+    assert verify_vf_address(dut, pf, 1, mac_1)


### PR DESCRIPTION
Objective(s): Test and ensure that duplicate mac address across VFs on the same PF is permitted

Test report: https://redhat-eets.github.io/pytest-reports/PR86.html