### PR TITLE
Adding SR_IOV_RandomlyTerminate_DPDK (originally pkstress)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Two ports of the NIC under test are directly connected to the traffic generator 
 On the DUT server, the following RPM packages are required,
 * tmux
 * nmap
+* podman
 
 To install,
 ```
@@ -68,7 +69,7 @@ Besides `tests/testbed.yaml`, the script will also look for `tests/config.yaml`.
 ```
 dpdk_img: "docker.io/patrickkutch/dpdk:v21.11"  # DPDK build container image
 github_tests_path:                # URL to the test directory
-                                  # example: https://github.com/redhat-partner-solutions/intel-sriov-test/tree/main/sriov/tests
+                                  # example: https://github.com/redhat-partner-solutions/rhel-sriov-test/tree/main/sriov/tests
 tests_doc_file: 	                # test specification name under the test case directory
                                   # example: "README.md"
 tests_name_field: 	              # name field in the test specification

--- a/README.md
+++ b/README.md
@@ -67,16 +67,20 @@ Besides `tests/testbed.yaml`, the script will also look for `tests/config.yaml`.
 
 ```
 dpdk_img: "docker.io/patrickkutch/dpdk:v21.11"  # DPDK build container image
-github_tests_path:              # URL to the test directory
-                                # example: https://github.com/redhat-partner-solutions/intel-sriov-test/tree/main/sriov/tests
-tests_doc_file: 	              # test specification name under the test case directory
-                                # example: "README.md"
-tests_name_field: 	            # name field in the test specification
-                                # example: "Test Case Name:"
-randomly_terminate_test_chance: # percentage chance to randomly terminate testpmd in test_SR_IOV_Randomly_Terminate_DPDK, from 0.0 to 1.0
-                                # example: 0.5
-randomly_terminate_test_length: # amount of time, in minutes, to run test_SR_IOV_Randomly_Terminate_DPDK
-                                # example: 10.5
+github_tests_path:                # URL to the test directory
+                                  # example: https://github.com/redhat-partner-solutions/intel-sriov-test/tree/main/sriov/tests
+tests_doc_file: 	                # test specification name under the test case directory
+                                  # example: "README.md"
+tests_name_field: 	              # name field in the test specification
+                                  # example: "Test Case Name:"
+randomly_terminate_control_core:  # the cpu core to share across testpmd sessions 
+                                  # example: 2
+randomly_terminate_max_vfs:       # a limit to put on the number of testpmd sessions and VFs
+                                  # example: 8
+randomly_terminate_test_chance:   # percentage chance to randomly terminate testpmd in test_SR_IOV_Randomly_Terminate_DPDK, from 0.0 to 1.0
+                                  # example: 0.5
+randomly_terminate_test_length:   # amount of time, in minutes, to run test_SR_IOV_Randomly_Terminate_DPDK
+                                  # example: 10.5
 ```
 
 Running the script from a python3 virtual environment is recommended. Install the required python modules,

--- a/README.md
+++ b/README.md
@@ -67,12 +67,16 @@ Besides `tests/testbed.yaml`, the script will also look for `tests/config.yaml`.
 
 ```
 dpdk_img: "docker.io/patrickkutch/dpdk:v21.11"  # DPDK build container image
-github_tests_path:          # URL to the test directory
-                            # example: https://github.com/redhat-partner-solutions/intel-sriov-test/tree/main/sriov/tests
-tests_doc_file: 	          # test specification name under the test case directory
-                            # example: "README.md"
-tests_name_field: 	        # name field in the test specification
-                            # example: "Test Case Name:"
+github_tests_path:              # URL to the test directory
+                                # example: https://github.com/redhat-partner-solutions/intel-sriov-test/tree/main/sriov/tests
+tests_doc_file: 	              # test specification name under the test case directory
+                                # example: "README.md"
+tests_name_field: 	            # name field in the test specification
+                                # example: "Test Case Name:"
+randomly_terminate_test_chance: # percentage chance to randomly terminate testpmd in test_SR_IOV_Randomly_Terminate_DPDK, from 0.0 to 1.0
+                                # example: 0.5
+randomly_terminate_test_length: # amount of time, in minutes, to run test_SR_IOV_Randomly_Terminate_DPDK
+                                # example: 10.5
 ```
 
 Running the script from a python3 virtual environment is recommended. Install the required python modules,

--- a/sriov/common/test_utils_mock.py
+++ b/sriov/common/test_utils_mock.py
@@ -4,6 +4,7 @@ from sriov.common.utils import (
     verify_vf_address,
     get_pci_address,
     bind_driver,
+    get_driver,
     config_interface,
     clear_interface,
     add_arp_entry,
@@ -47,6 +48,10 @@ class UtilsTest(unittest.TestCase):
     def test_bind_driver(self):
         ssh_obj = self.create_mock_ssh_obj()
         assert bind_driver(ssh_obj, "0000:00:00.0", "vfio-pci") is True
+
+    def test_get_driver(self):
+        ssh_obj = self.create_mock_ssh_obj(0, ["ice"], "")
+        assert get_driver(ssh_obj, "ens2f3") == "ice"
 
     def test_config_interface(self):
         ssh_obj = self.create_mock_ssh_obj()

--- a/sriov/common/utils.py
+++ b/sriov/common/utils.py
@@ -717,3 +717,28 @@ def stop_testpmd_in_tmux(ssh_obj: ShellHandler, tmux_session: str) -> None:
     ssh_obj.execute(cmd)
     time.sleep(1)
     assert stop_tmux(ssh_obj, tmux_session)
+
+
+def get_isolated_cpus(ssh_obj: ShellHandler) -> list:
+    """Return a list of the isolated CPUs
+
+    Args:
+        ssh_obj (ShellHandler): ssh connection obj
+
+    Returns:
+        list: The list of isolated CPUs
+    """
+    cmd = ["cat /sys/devices/system/cpu/isolated"]
+    outs, errs = execute_and_assert(ssh_obj, cmd, 0)
+    isolated = outs[0][0]
+    isolated_cores = isolated.split(",")
+    isolated_list = []
+    for core in isolated_cores:
+        if "-" not in core:
+            isolated_list.append(int(core))
+        else:
+            a, b = core.split("-")
+            sub_list = list(range(int(a), int(b) + 1))
+            isolated_list.extend(sub_list)
+
+    return isolated_list

--- a/sriov/common/utils.py
+++ b/sriov/common/utils.py
@@ -656,7 +656,7 @@ def execute_and_assert(
 
 
 def execute_until_timeout(
-    ssh_obj: ShellHandler, cmd: str, timeout: int = 10, exit_code=0
+    ssh_obj: ShellHandler, cmd: str, timeout: int = 10, exit_code: int = 0
 ) -> bool:
     """Execute cmd and check for exit code until timeout
 
@@ -664,6 +664,7 @@ def execute_until_timeout(
         ssh_obj:         ssh connection obj
         cmd (str):       a single command to run
         timeout (int):   optional timeout between cmds (default 10)
+        exit_code (int): optional code to check for (default 0)
 
     Returns:
         True: cmd return exit code 0 before timeout

--- a/sriov/tests/SR_IOV_RandomlyTerminate_DPDK/README.md
+++ b/sriov/tests/SR_IOV_RandomlyTerminate_DPDK/README.md
@@ -1,0 +1,48 @@
+## Test Case Name: SR-IOV.RandomlyTerminate.DPDK
+
+### Objective(s): A robustness test to ensure that randomly killed and restarted testpmd containers recover. Permutations are necessary for random termination, random termination with iavf binding, and random termination when resetting the PF.
+
+### Test procedure
+
+* Reset the VFs
+```
+echo 0 > /sys/class/net/$PF/device/sriov_numvfs
+```
+
+* Ensure the reset succeeds (or check no VF exists under the ```$PF``` by ensuring ```sriov_numvfs``` is 0)
+
+* Bind the device driver (i.e. ice)
+
+* Set hugepages
+```
+echo 2048 > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+mkdir -p /mnt/huge
+mount -t hugetlbfs nodev /mnt/huge
+echo 8196 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages
+echo 8196 > /sys/devices/system/node/node1/hugepages/hugepages-2048kB/nr_hugepages
+```
+
+* Kill all running containers
+
+* Set the link up and create the number of VFs desired, wait up to 10 seconds for all VFs to be created
+```
+modprobe vfio-pci
+ip link set $PF up
+echo ${num_vfs} > /sys/class/net/$PF/device/sriov_numvfs
+```
+
+* Start pinging the dut from the trafficgen
+
+* Start containers
+
+* Randomly kill containers
+
+* Rebind iavf or reset PF, if required by permutation
+
+* Restart containers, checking all are up and transmitting after restart
+
+
+### Clean up
+```
+echo 0 > /sys/class/net/$PF/device/sriov_numvfs
+```

--- a/sriov/tests/SR_IOV_RandomlyTerminate_DPDK/test_SR_IOV_RandomlyTerminate_DPDK.py
+++ b/sriov/tests/SR_IOV_RandomlyTerminate_DPDK/test_SR_IOV_RandomlyTerminate_DPDK.py
@@ -4,14 +4,12 @@ import time
 from sriov.common.utils import (
     get_driver,
     start_tmux,
-    stop_tmux,
     create_vfs,
     execute_and_assert,
     execute_until_timeout,
     bind_driver,
     wait_tmux_testpmd_ready,
     stop_testpmd_in_tmux,
-    prepare_ping_test,
 )
 
 
@@ -39,28 +37,22 @@ def test_SR_IOV_RandomlyTerminate_DPDK(dut, trafficgen, settings, testdata, opti
         + str(settings.config["randomly_terminate_test_chance"])
     )
 
-    trafficgen_pf = settings.config["trafficgen"]["interface"]["pf1"]["name"]
-    trafficgen_ip = testdata.trafficgen_ip
-    dut_ip = testdata.dut_ip
-    vf0_mac = testdata.dut_mac
+    if "randomly_terminate_test_chance" not in settings.config:
+        assert False, "randomly_terminate_test_chance not set in config"
+
     pf = settings.config["dut"]["interface"]["pf1"]["name"]
-    pf_pci = settings.config["dut"]["interface"]["pf1"]["pci"]
+    pf_dev_pci = settings.config["dut"]["interface"]["pf1"]["pci"][0:8] + "00.0"
 
     # Bind the PF driver
     pf_driver = get_driver(dut, pf)
-    assert bind_driver(dut, pf_pci, pf_driver)
+    assert bind_driver(dut, pf_dev_pci, pf_driver)
 
     # Set hugepages (NOTE: Currently not implemented in any tests)
 
     # Set PF up and create VFs
     steps = ["modprobe vfio-pci", f"ip link set {pf} up"]
     execute_and_assert(dut, steps, 0, 0.1)
-
     assert create_vfs(dut, pf, 2)
-
-    # Set vf0 mac
-    cmd = [f"ip link set {pf} vf 0 mac {vf0_mac}"]
-    execute_and_assert(dut, cmd, 0)
 
     # Bind VF0 to vfio-pci
     vf_pci = settings.config["dut"]["interface"]["vf1"]["pci"]
@@ -75,76 +67,50 @@ def test_SR_IOV_RandomlyTerminate_DPDK(dut, trafficgen, settings, testdata, opti
         "-v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules "
         f"--cpuset-cpus {cpus} {dpdk_img} dpdk-testpmd -l {cpus} "
         f"-n 4 -a {vf_pci} "
-        "-- --nb-cores=2 -i"
+        "-- --nb-cores=2 --forward=txonly -i"
     )
     print(tmux_cmd)
     tmux_session = testdata.tmux_session_name
     assert start_tmux(dut, tmux_session, tmux_cmd)
 
-    trafficgen_vlan = 0
-    trafficgen_mac = None  # None means no need to set arp entry on DUT
-    assert prepare_ping_test(
-        trafficgen,
-        trafficgen_pf,
-        trafficgen_vlan,
-        trafficgen_ip,
-        trafficgen_mac,
-        dut,
-        dut_ip,
-        vf0_mac,
-        testdata,
-    )
-
-    ping_cmd = f"ping -W 1 -i 0.2 {dut_ip}"
-    assert start_tmux(trafficgen, "ping_tmux", ping_cmd)
-
     end = time.time() + 60 * settings.config["randomly_terminate_test_length"]
     while end > time.time():
         assert wait_tmux_testpmd_ready(dut, tmux_session, 15)
-        if "randomly_terminate_test_chance" in settings.config:
-            if random.random() < settings.config["randomly_terminate_test_chance"]:
-                steps = [f"podman kill {name}"]
-                execute_and_assert(dut, steps, 0)
 
-                # Ensure that the container is killed before proceeding
-                steps = f"podman ps | grep {name}"
-                execute_until_timeout(dut, steps, 10, 1)
+        if random.random() < settings.config["randomly_terminate_test_chance"]:
+            steps = [f"podman kill {name}"]
+            execute_and_assert(dut, steps, 0)
 
-                if options:
-                    if options == "rebind_pf":
-                        assert bind_driver(dut, pf_pci, pf_driver)
-                    elif options == "rebind_vf":
-                        assert bind_driver(dut, vf_pci, "vfio-pci")
-                assert start_tmux(dut, tmux_session, tmux_cmd)
-                assert wait_tmux_testpmd_ready(dut, tmux_session, 15)
+            # Ensure that the container is killed before proceeding
+            steps = f"podman ps | grep {name}"
+            execute_until_timeout(dut, steps, 10, 1)
 
-                # Baseline stats
-                stats_steps = [
-                    f"tmux send-keys -t {tmux_session} 'show fwd stats all' ENTER",
-                    f"tmux capture-pane -pt {tmux_session} | grep TX-packets",
-                ]
-                stats_outs, errs = execute_and_assert(dut, stats_steps, 0)
+            if options:
+                if options == "rebind_pf":
+                    assert bind_driver(dut, pf_dev_pci, pf_driver)
+                elif options == "rebind_vf":
+                    assert bind_driver(dut, vf_pci, "vfio-pci")
+            assert start_tmux(dut, tmux_session, tmux_cmd)
+            assert wait_tmux_testpmd_ready(dut, tmux_session, 15)
 
-                steps = [
-                    f"tmux send-keys -t {tmux_session} 'set fwd icmpecho' ENTER",
-                    f"tmux send-keys -t {tmux_session} 'start' ENTER",
-                ]
-                execute_and_assert(dut, steps, 0)
+            steps = [
+                f"tmux send-keys -t {tmux_session} 'start' ENTER",
+            ]
+            execute_and_assert(dut, steps, 0)
 
-                # Wait one ping before attempting to assess if testpmd if transmitting
-                time.sleep(0.2)
-                # Check stats after setting icmpecho and starting testpmd
-                stats_outs_2, errs = execute_and_assert(dut, stats_steps, 0)
+            # Baseline stats
+            stats_steps = [
+                f"tmux send-keys -t {tmux_session} 'show fwd stats all' ENTER",
+                f"tmux capture-pane -pt {tmux_session} | tail -4 | grep TX-packets",
+            ]
+            stats_outs, errs = execute_and_assert(dut, stats_steps, 0)
+            stats_outs_2, errs = execute_and_assert(dut, stats_steps, 0)
 
-                if stats_outs[1] == stats_outs_2[1]:
-                    print(stats_outs)
-                    print(stats_outs_2)
-                    stop_testpmd_in_tmux(dut, tmux_session)
-                    assert False, "testpmd not transmitting"
+            if stats_outs[1] == stats_outs_2[1]:
+                print(stats_outs)
+                print(stats_outs_2)
+                stop_testpmd_in_tmux(dut, tmux_session)
+                assert False, "testpmd not transmitting"
 
-        else:
-            stop_testpmd_in_tmux(dut, tmux_session)
-            assert False, "randomly_terminate_test_chance not set in config"
-
-    assert stop_tmux(trafficgen, "ping_tmux")
+    # assert stop_tmux(trafficgen, "ping_tmux")
     stop_testpmd_in_tmux(dut, tmux_session)

--- a/sriov/tests/SR_IOV_RandomlyTerminate_DPDK/test_SR_IOV_RandomlyTerminate_DPDK.py
+++ b/sriov/tests/SR_IOV_RandomlyTerminate_DPDK/test_SR_IOV_RandomlyTerminate_DPDK.py
@@ -20,7 +20,7 @@ def get_podman_cmd(name, cpus, dpdk_img, vf_pci):
         "-v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules "
         f"--cpuset-cpus {cpus} {dpdk_img} dpdk-testpmd -l {cpus} "
         f"-n 4 -a {vf_pci} "
-        "-- --nb-cores=2 --forward=txonly -i"
+        "-- --nb-cores=1 --forward=txonly -i"
     )
     return tmux_cmd
 
@@ -29,9 +29,7 @@ def get_testpmd_cpus(control_core, i):
     cpus = (
         str(control_core)
         + ","
-        + str(control_core + (i * 2) + 1)
-        + ","
-        + str(control_core + (i * 2) + 2)
+        + str(control_core + i + 1)
     )
     return cpus
 
@@ -96,8 +94,8 @@ def test_SR_IOV_RandomlyTerminate_DPDK(dut, settings, testdata, options):
     max_cpus_cmd = ["grep -c processor /proc/cpuinfo"]
     outs, errs = execute_and_assert(dut, max_cpus_cmd, 0)
     max_cpus = int(
-        int(outs[0][0].strip()) / 2 - 3
-    )  # 2 cores for housekeeping, 1 control core
+        int(outs[0][0].strip()) - 3  # 2 cores for housekeeping, 1 control core
+    )
 
     # Create the minimum acceptable number of VFs
     num_vfs = min(max_vfs, max_cpus, settings.config["randomly_terminate_max_vfs"])

--- a/sriov/tests/SR_IOV_RandomlyTerminate_DPDK/test_SR_IOV_RandomlyTerminate_DPDK.py
+++ b/sriov/tests/SR_IOV_RandomlyTerminate_DPDK/test_SR_IOV_RandomlyTerminate_DPDK.py
@@ -1,0 +1,150 @@
+import pytest
+import random
+import time
+from sriov.common.utils import (
+    get_driver,
+    start_tmux,
+    stop_tmux,
+    create_vfs,
+    execute_and_assert,
+    execute_until_timeout,
+    bind_driver,
+    wait_tmux_testpmd_ready,
+    stop_testpmd_in_tmux,
+    prepare_ping_test,
+)
+
+
+@pytest.mark.parametrize("options", (None, "rebind_pf", "rebind_vf"))
+def test_SR_IOV_RandomlyTerminate_DPDK(dut, trafficgen, settings, testdata, options):
+    """A robustness test to ensure that randomly killed and restarted testpmd containers
+       recover. Permutations are necessary for random termination, random termination
+       with iavf binding, and resetting the PF. Adapted from the original pkstress shell
+       script written by Patrick Kutch.
+
+    Args:
+        dut:        ssh connection obj
+        trafficgen: ssh connection obj
+        settings:   settings obj
+        testdata:   testdata obj
+        options:    None, rebind_pf, or rebind_vf
+    """
+    print(
+        "Test length: "
+        + str(settings.config["randomly_terminate_test_length"])
+        + " minutes"
+    )
+    print(
+        "Chance of killing testpmd: "
+        + str(settings.config["randomly_terminate_test_chance"])
+    )
+
+    trafficgen_pf = settings.config["trafficgen"]["interface"]["pf1"]["name"]
+    trafficgen_ip = testdata.trafficgen_ip
+    dut_ip = testdata.dut_ip
+    vf0_mac = testdata.dut_mac
+    pf = settings.config["dut"]["interface"]["pf1"]["name"]
+    pf_pci = settings.config["dut"]["interface"]["pf1"]["pci"]
+
+    # Bind the PF driver
+    pf_driver = get_driver(dut, pf)
+    assert bind_driver(dut, pf_pci, pf_driver)
+
+    # Set hugepages (NOTE: Currently not implemented in any tests)
+
+    # Set PF up and create VFs
+    steps = ["modprobe vfio-pci", f"ip link set {pf} up"]
+    execute_and_assert(dut, steps, 0, 0.1)
+
+    assert create_vfs(dut, pf, 2)
+
+    # Set vf0 mac
+    cmd = [f"ip link set {pf} vf 0 mac {vf0_mac}"]
+    execute_and_assert(dut, cmd, 0)
+
+    # Bind VF0 to vfio-pci
+    vf_pci = settings.config["dut"]["interface"]["vf1"]["pci"]
+    assert bind_driver(dut, vf_pci, "vfio-pci")
+
+    # Start first instance of testpmd in echo mode
+    dpdk_img = settings.config["dpdk_img"]
+    cpus = settings.config["dut"]["pmd_cpus"]
+    name = "random_terminate"
+    tmux_cmd = (
+        f"podman run -it --name {name} --rm --privileged "
+        "-v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules "
+        f"--cpuset-cpus {cpus} {dpdk_img} dpdk-testpmd -l {cpus} "
+        f"-n 4 -a {vf_pci} "
+        "-- --nb-cores=2 -i"
+    )
+    print(tmux_cmd)
+    tmux_session = testdata.tmux_session_name
+    assert start_tmux(dut, tmux_session, tmux_cmd)
+
+    trafficgen_vlan = 0
+    trafficgen_mac = None  # None means no need to set arp entry on DUT
+    assert prepare_ping_test(
+        trafficgen,
+        trafficgen_pf,
+        trafficgen_vlan,
+        trafficgen_ip,
+        trafficgen_mac,
+        dut,
+        dut_ip,
+        vf0_mac,
+        testdata,
+    )
+
+    ping_cmd = f"ping -W 1 -i 0.2 {dut_ip}"
+    assert start_tmux(trafficgen, "ping_tmux", ping_cmd)
+
+    end = time.time() + 60 * settings.config["randomly_terminate_test_length"]
+    while end > time.time():
+        assert wait_tmux_testpmd_ready(dut, tmux_session, 15)
+        if "randomly_terminate_test_chance" in settings.config:
+            if random.random() < settings.config["randomly_terminate_test_chance"]:
+                steps = [f"podman kill {name}"]
+                execute_and_assert(dut, steps, 0)
+
+                # Ensure that the container is killed before proceeding
+                steps = f"podman ps | grep {name}"
+                execute_until_timeout(dut, steps, 10, 1)
+
+                if options:
+                    if options == "rebind_pf":
+                        assert bind_driver(dut, pf_pci, pf_driver)
+                    elif options == "rebind_vf":
+                        assert bind_driver(dut, vf_pci, "vfio-pci")
+                assert start_tmux(dut, tmux_session, tmux_cmd)
+                assert wait_tmux_testpmd_ready(dut, tmux_session, 15)
+
+                # Baseline stats
+                stats_steps = [
+                    f"tmux send-keys -t {tmux_session} 'show fwd stats all' ENTER",
+                    f"tmux capture-pane -pt {tmux_session} | grep TX-packets",
+                ]
+                stats_outs, errs = execute_and_assert(dut, stats_steps, 0)
+
+                steps = [
+                    f"tmux send-keys -t {tmux_session} 'set fwd icmpecho' ENTER",
+                    f"tmux send-keys -t {tmux_session} 'start' ENTER",
+                ]
+                execute_and_assert(dut, steps, 0)
+
+                # Wait one ping before attempting to assess if testpmd if transmitting
+                time.sleep(0.2)
+                # Check stats after setting icmpecho and starting testpmd
+                stats_outs_2, errs = execute_and_assert(dut, stats_steps, 0)
+
+                if stats_outs[1] == stats_outs_2[1]:
+                    print(stats_outs)
+                    print(stats_outs_2)
+                    stop_testpmd_in_tmux(dut, tmux_session)
+                    assert False, "testpmd not transmitting"
+
+        else:
+            stop_testpmd_in_tmux(dut, tmux_session)
+            assert False, "randomly_terminate_test_chance not set in config"
+
+    assert stop_tmux(trafficgen, "ping_tmux")
+    stop_testpmd_in_tmux(dut, tmux_session)

--- a/sriov/tests/SR_IOV_RandomlyTerminate_DPDK/test_SR_IOV_RandomlyTerminate_DPDK.py
+++ b/sriov/tests/SR_IOV_RandomlyTerminate_DPDK/test_SR_IOV_RandomlyTerminate_DPDK.py
@@ -136,8 +136,8 @@ def test_SR_IOV_RandomlyTerminate_DPDK(dut, settings, testdata, options):
                 execute_and_assert(dut, steps, 0)
 
                 # Ensure that the container is killed before proceeding
-                steps = f"podman ps | grep {name}"
-                execute_until_timeout(dut, steps, 10, 1)
+                steps = f"podman ps -f name={name}$ | grep {name}"
+                assert execute_until_timeout(dut, steps, 10, 1)
 
                 # Restart the container, as well as rebind drivers if required
                 if options:

--- a/sriov/tests/SR_IOV_RandomlyTerminate_DPDK/test_SR_IOV_RandomlyTerminate_DPDK.py
+++ b/sriov/tests/SR_IOV_RandomlyTerminate_DPDK/test_SR_IOV_RandomlyTerminate_DPDK.py
@@ -10,11 +10,39 @@ from sriov.common.utils import (
     bind_driver,
     wait_tmux_testpmd_ready,
     stop_testpmd_in_tmux,
+    get_pci_address,
 )
 
 
+def get_podman_cmd(name, cpus, dpdk_img, vf_pci):
+    tmux_cmd = (
+        f"podman run -it --name {name} --rm --privileged "
+        "-v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules "
+        f"--cpuset-cpus {cpus} {dpdk_img} dpdk-testpmd -l {cpus} "
+        f"-n 4 -a {vf_pci} "
+        "-- --nb-cores=2 --forward=txonly -i"
+    )
+    return tmux_cmd
+
+
+def get_testpmd_cpus(control_core, i):
+    cpus = (
+        str(control_core)
+        + ","
+        + str(control_core + (i * 2) + 1)
+        + ","
+        + str(control_core + (i * 2) + 2)
+    )
+    return cpus
+
+
+def stop_all_testpmd(dut, tmux_list):
+    for tmux_session, vf_pci in tmux_list:
+        stop_testpmd_in_tmux(dut, tmux_session)
+
+
 @pytest.mark.parametrize("options", (None, "rebind_pf", "rebind_vf"))
-def test_SR_IOV_RandomlyTerminate_DPDK(dut, trafficgen, settings, testdata, options):
+def test_SR_IOV_RandomlyTerminate_DPDK(dut, settings, testdata, options):
     """A robustness test to ensure that randomly killed and restarted testpmd containers
        recover. Permutations are necessary for random termination, random termination
        with iavf binding, and resetting the PF. Adapted from the original pkstress shell
@@ -22,7 +50,6 @@ def test_SR_IOV_RandomlyTerminate_DPDK(dut, trafficgen, settings, testdata, opti
 
     Args:
         dut:        ssh connection obj
-        trafficgen: ssh connection obj
         settings:   settings obj
         testdata:   testdata obj
         options:    None, rebind_pf, or rebind_vf
@@ -39,7 +66,14 @@ def test_SR_IOV_RandomlyTerminate_DPDK(dut, trafficgen, settings, testdata, opti
 
     if "randomly_terminate_test_chance" not in settings.config:
         assert False, "randomly_terminate_test_chance not set in config"
+    elif "randomly_terminate_max_vfs" not in settings.config:
+        assert False, "randomly_terminate_max_vfs not set in config"
+    elif "randomly_terminate_control_core" not in settings.config:
+        assert False, "randomly_terminate_control_core not set in config"
+    elif "randomly_terminate_test_length" not in settings.config:
+        assert False, "randomly_terminate_test_length not set in config"
 
+    # Set the PF and PF device PCI address
     pf = settings.config["dut"]["interface"]["pf1"]["name"]
     pf_dev_pci = settings.config["dut"]["interface"]["pf1"]["pci"][0:8] + "00.0"
 
@@ -49,68 +83,92 @@ def test_SR_IOV_RandomlyTerminate_DPDK(dut, trafficgen, settings, testdata, opti
 
     # Set hugepages (NOTE: Currently not implemented in any tests)
 
-    # Set PF up and create VFs
+    # Set PF up
     steps = ["modprobe vfio-pci", f"ip link set {pf} up"]
     execute_and_assert(dut, steps, 0, 0.1)
-    assert create_vfs(dut, pf, 2)
 
-    # Bind VF0 to vfio-pci
-    vf_pci = settings.config["dut"]["interface"]["vf1"]["pci"]
-    assert bind_driver(dut, vf_pci, "vfio-pci")
+    # Get maximum amount of VFs
+    max_vfs_cmd = ["cat /sys/class/net/" + pf + "/device/sriov_totalvfs"]
+    outs, errs = execute_and_assert(dut, max_vfs_cmd, 0)
+    max_vfs = int(outs[0][0].strip())
 
-    # Start first instance of testpmd in echo mode
+    # Get maximum amount of CPUs
+    max_cpus_cmd = ["grep -c processor /proc/cpuinfo"]
+    outs, errs = execute_and_assert(dut, max_cpus_cmd, 0)
+    max_cpus = int(
+        int(outs[0][0].strip()) / 2 - 3
+    )  # 2 cores for housekeeping, 1 control core
+
+    # Create the minimum acceptable number of VFs
+    num_vfs = min(max_vfs, max_cpus, settings.config["randomly_terminate_max_vfs"])
+    assert create_vfs(dut, pf, num_vfs)
+
+    base_name = "random_terminate"
     dpdk_img = settings.config["dpdk_img"]
-    cpus = settings.config["dut"]["pmd_cpus"]
-    name = "random_terminate"
-    tmux_cmd = (
-        f"podman run -it --name {name} --rm --privileged "
-        "-v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules "
-        f"--cpuset-cpus {cpus} {dpdk_img} dpdk-testpmd -l {cpus} "
-        f"-n 4 -a {vf_pci} "
-        "-- --nb-cores=2 --forward=txonly -i"
-    )
-    print(tmux_cmd)
-    tmux_session = testdata.tmux_session_name
-    assert start_tmux(dut, tmux_session, tmux_cmd)
+    tmux_list = []
+    for i in range(num_vfs):
+        # Bind VF0 to vfio-pci
+        vf_pci = get_pci_address(dut, pf + "v" + str(i))
+        assert bind_driver(dut, vf_pci, "vfio-pci")
+
+        cpus = get_testpmd_cpus(settings.config["randomly_terminate_control_core"], i)
+        name = base_name + str(i)
+        tmux_cmd = get_podman_cmd(name, cpus, dpdk_img, vf_pci)
+
+        # Start instance of testpmd
+        tmux_session = testdata.tmux_session_name + str(i)
+        assert start_tmux(dut, tmux_session, tmux_cmd)
+        assert wait_tmux_testpmd_ready(dut, tmux_session, 15)
+        tmux_list.append([tmux_session, vf_pci])
 
     end = time.time() + 60 * settings.config["randomly_terminate_test_length"]
     while end > time.time():
-        assert wait_tmux_testpmd_ready(dut, tmux_session, 15)
+        for i in range(num_vfs):
+            if random.random() < settings.config["randomly_terminate_test_chance"]:
+                cpus = get_testpmd_cpus(
+                    settings.config["randomly_terminate_control_core"], i
+                )
+                name = base_name + str(i)
+                tmux_session = tmux_list[i][0]
+                vf_pci = tmux_list[i][1]
+                tmux_cmd = get_podman_cmd(name, cpus, dpdk_img, vf_pci)
 
-        if random.random() < settings.config["randomly_terminate_test_chance"]:
-            steps = [f"podman kill {name}"]
-            execute_and_assert(dut, steps, 0)
+                # Kill the container
+                steps = [f"podman kill {name}"]
+                execute_and_assert(dut, steps, 0)
 
-            # Ensure that the container is killed before proceeding
-            steps = f"podman ps | grep {name}"
-            execute_until_timeout(dut, steps, 10, 1)
+                # Ensure that the container is killed before proceeding
+                steps = f"podman ps | grep {name}"
+                execute_until_timeout(dut, steps, 10, 1)
 
-            if options:
-                if options == "rebind_pf":
-                    assert bind_driver(dut, pf_dev_pci, pf_driver)
-                elif options == "rebind_vf":
-                    assert bind_driver(dut, vf_pci, "vfio-pci")
-            assert start_tmux(dut, tmux_session, tmux_cmd)
-            assert wait_tmux_testpmd_ready(dut, tmux_session, 15)
+                # Restart the container, as well as rebind drivers if required
+                if options:
+                    if options == "rebind_pf":
+                        assert bind_driver(dut, pf_dev_pci, pf_driver)
+                    elif options == "rebind_vf":
+                        assert bind_driver(dut, vf_pci, "vfio-pci")
+                assert start_tmux(dut, tmux_session, tmux_cmd)
+                assert wait_tmux_testpmd_ready(dut, tmux_session, 15)
 
-            steps = [
-                f"tmux send-keys -t {tmux_session} 'start' ENTER",
-            ]
-            execute_and_assert(dut, steps, 0)
+                # Start testpmd
+                steps = [
+                    f"tmux send-keys -t {tmux_session} 'start' ENTER",
+                ]
+                execute_and_assert(dut, steps, 0)
 
-            # Baseline stats
-            stats_steps = [
-                f"tmux send-keys -t {tmux_session} 'show fwd stats all' ENTER",
-                f"tmux capture-pane -pt {tmux_session} | tail -4 | grep TX-packets",
-            ]
-            stats_outs, errs = execute_and_assert(dut, stats_steps, 0)
-            stats_outs_2, errs = execute_and_assert(dut, stats_steps, 0)
+                # Baseline stats
+                stats_steps = [
+                    f"tmux send-keys -t {tmux_session} 'show fwd stats all' ENTER",
+                    f"tmux capture-pane -pt {tmux_session} | tail -4 | grep TX-packets",
+                ]
+                stats_outs, errs = execute_and_assert(dut, stats_steps, 0)
+                stats_outs_2, errs = execute_and_assert(dut, stats_steps, 0)
 
-            if stats_outs[1] == stats_outs_2[1]:
-                print(stats_outs)
-                print(stats_outs_2)
-                stop_testpmd_in_tmux(dut, tmux_session)
-                assert False, "testpmd not transmitting"
+                # Ensure testpmd is transmitting
+                if stats_outs[1] == stats_outs_2[1]:
+                    print(stats_outs)
+                    print(stats_outs_2)
+                    stop_all_testpmd(dut, tmux_list)
+                    assert False, "testpmd not transmitting"
 
-    # assert stop_tmux(trafficgen, "ping_tmux")
-    stop_testpmd_in_tmux(dut, tmux_session)
+    stop_all_testpmd(dut, tmux_list)

--- a/sriov/tests/common/test_utils.py
+++ b/sriov/tests/common/test_utils.py
@@ -1,4 +1,5 @@
 from sriov.common.utils import (
+    get_driver,
     bind_driver,
     start_tmux,
     stop_tmux,
@@ -34,6 +35,11 @@ def test_get_pci_address(dut, settings):
     vf_pci = settings.config["dut"]["interface"]["vf1"]["pci"]
     vf_name = settings.config["dut"]["interface"]["vf1"]["name"]
     assert vf_pci == get_pci_address(dut, vf_name)
+
+
+def test_get_driver(dut, settings):
+    pf_name = settings.config["dut"]["interface"]["pf1"]["name"]
+    assert get_driver(dut, pf_name) == "ice"
 
 
 def test_bind_driver(dut, settings):

--- a/sriov/tests/config_template.yaml
+++ b/sriov/tests/config_template.yaml
@@ -2,5 +2,7 @@ dpdk_img: "docker.io/patrickkutch/dpdk:v21.11"
 tests_name_field: "Test Case Name:"
 tests_doc_file: "README.md"
 github_tests_path: "https://github.com/redhat-partner-solutions/intel-sriov-test/tree/main/sriov/tests"
+randomly_terminate_control_core: 2
+randomly_terminate_max_vfs: 8
 randomly_terminate_test_chance: 0.5
-randomly_terminate_test_length: 10
+randomly_terminate_test_length: 10.5

--- a/sriov/tests/config_template.yaml
+++ b/sriov/tests/config_template.yaml
@@ -2,3 +2,5 @@ dpdk_img: "docker.io/patrickkutch/dpdk:v21.11"
 tests_name_field: "Test Case Name:"
 tests_doc_file: "README.md"
 github_tests_path: "https://github.com/redhat-partner-solutions/intel-sriov-test/tree/main/sriov/tests"
+randomly_terminate_test_chance: 0.5
+randomly_terminate_test_length: 10

--- a/sriov/tests/config_template.yaml
+++ b/sriov/tests/config_template.yaml
@@ -1,7 +1,7 @@
 dpdk_img: "docker.io/patrickkutch/dpdk:v21.11"
 tests_name_field: "Test Case Name:"
 tests_doc_file: "README.md"
-github_tests_path: "https://github.com/redhat-partner-solutions/intel-sriov-test/tree/main/sriov/tests"
+github_tests_path: "https://github.com/redhat-partner-solutions/rhel-sriov-test/tree/main/sriov/tests"
 randomly_terminate_control_core: 2
 randomly_terminate_max_vfs: 8
 randomly_terminate_test_chance: 0.5


### PR DESCRIPTION
Adding initial working version of SR_IOV_RandomlyTerminate_DPDK:

Refactoring is incoming, as some fields need to be moved to config, snippets moved to utils, etc.

Implementation of SR_IOV_RandomlyTerminate_DPDK and documentation:

Working implementation of randomly terminating, as well as permutations for vf and pf rebinding Moved chance to terminate and length of test to config Updated root level README and test README to reflect updates

Adding logs for length and chance

Updating unit tests for get_driver

Updating mock test for comparison

NOTE: Tangentially related updates, specifically generic instantiation of the container manager and setting up hugepages, are outside of the scope of this specific work item. They require widespread changes that span multiple test cases, and so will be completed in separate PRs.

test report (3 minutes per, 0.75 chance): https://gist.github.com/dkosteck/a6c7ae02eab176983c262d8a86187f9f
common report: https://gist.github.com/dkosteck/d515b332b4fb7d09c8acea96a868892d
added test report (30 minutes per, 0.75 chance [over 1000 restarts]): https://gist.github.com/dkosteck/75d6574c042b6745218a72b487c93ac2