### PR TITLE
Added an IPv6 test to verify that the VF admin MAC address can be explicitly set

### DIFF
--- a/sriov/common/configtestdata.py
+++ b/sriov/common/configtestdata.py
@@ -11,9 +11,11 @@ class ConfigTestData:
         """
         self.vlan = 10
         self.dut_ip = "101.1.1.2"
+        self.dut_ip_v6 = "2001::2"
         self.dut_mac = "aa:bb:cc:dd:ee:00"
         self.dut_spoof_mac = "aa:bb:cc:dd:ee:ff"
         self.trafficgen_ip = "101.1.1.1"
+        self.trafficgen_ip_v6 = "2001::1"
         self.trafficgen_spoof_mac = "aa:00:00:00:00:00"
         self.qos = 5
         self.max_tx_rate = 10

--- a/sriov/tests/SR_IOV_macAddress_IPv6/README.md
+++ b/sriov/tests/SR_IOV_macAddress_IPv6/README.md
@@ -1,0 +1,34 @@
+
+## Test Case Name: SR-IOV.macAddress.IPv6
+
+### Objective(s): Test and ensure that VF (virtual function) admin MAC address functions as intended with IPv6.
+
+### Test procedure
+
+* On trafficgen, clean up existing IPv6 address and neighbor discovery(ND) cache, and add an IPv6 address,
+```
+ip -6 add del ${TGEN_IPv6}/64 dev ${TGEN_PF}
+ip -6 neigh del ${DUT_IPv6} dev ${TGEN_PF}
+ip -6 add add ${TGEN_IPv6}/64 dev ${TGEN_PF}
+```
+
+* On DUT, clean up existing IPv6 ND cache, and create 1 VF and assign a mac address. Assert on 0 exit code of each of the following steps,
+```
+ip -6 neigh del {TGEN_IPv6} dev ${DUT_PF}
+echo 0 > /sys/class/net/${DUT_PF}/device/sriov_numvfs
+echo 1 > /sys/class/net/${DUT_PF}/device/sriov_numvfs
+ip link set ${DUT_PF}v0 down
+ip link set ${DUT_PF} vf 0 mac ${DUT_VF0_MAC}
+ip link set ${DU_PF}v0 up
+ip -6 add add ${DUT_IPv6}/64 dev ${DUT_PF}v0
+```
+
+* On trafficgen: assert on ping exit code 0
+```
+ping -6 -W 1 -c 1 ${DUT_IPv6}
+```
+
+### Clean up
+```
+echo 0 > /sys/class/net/${DUT_PF}/device/sriov_numvfs
+```

--- a/sriov/tests/SR_IOV_macAddress_IPv6/README.md
+++ b/sriov/tests/SR_IOV_macAddress_IPv6/README.md
@@ -7,20 +7,20 @@
 
 * On trafficgen, clean up existing IPv6 address and neighbor discovery(ND) cache, and add an IPv6 address,
 ```
-ip -6 add del ${TGEN_IPv6}/64 dev ${TGEN_PF}
-ip -6 neigh del ${DUT_IPv6} dev ${TGEN_PF}
-ip -6 add add ${TGEN_IPv6}/64 dev ${TGEN_PF}
+ip -6 address del ${TGEN_IPv6}/64 dev ${TGEN_PF}
+ip -6 neighbor del ${DUT_IPv6} dev ${TGEN_PF}
+ip -6 address add ${TGEN_IPv6}/64 dev ${TGEN_PF}
 ```
 
-* On DUT, clean up existing IPv6 ND cache, and create 1 VF and assign a mac address. Assert on 0 exit code of each of the following steps,
+* On DUT, clean up existing IPv6 ND cache, and create 1 VF and assign a MAC address. Assert on 0 exit code of each of the following steps,
 ```
-ip -6 neigh del {TGEN_IPv6} dev ${DUT_PF}
-echo 0 > /sys/class/net/${DUT_PF}/device/sriov_numvfs
+ip -6 neighbor del {TGEN_IPv6} dev ${DUT_PF}
+echo 0 > /sys /class/net/${DUT_PF}/device/sriov_numvfs
 echo 1 > /sys/class/net/${DUT_PF}/device/sriov_numvfs
 ip link set ${DUT_PF}v0 down
 ip link set ${DUT_PF} vf 0 mac ${DUT_VF0_MAC}
 ip link set ${DU_PF}v0 up
-ip -6 add add ${DUT_IPv6}/64 dev ${DUT_PF}v0
+ip -6 address add ${DUT_IPv6}/64 dev ${DUT_PF}v0
 ```
 
 * On trafficgen: assert on ping exit code 0

--- a/sriov/tests/SR_IOV_macAddress_IPv6/test_SR_IOV_macAddress_IPv6.py
+++ b/sriov/tests/SR_IOV_macAddress_IPv6/test_SR_IOV_macAddress_IPv6.py
@@ -25,7 +25,7 @@ def test_SR_IOV_macAddress_IPv6(dut, trafficgen, settings, testdata):
         f"ip -6 add del {trafficgen_ip_v6}/64 dev {trafficgen_pf} 2>/dev/null || true",
         f"ip -6 neigh del {dut_ip_v6}  dev {trafficgen_pf} || true",
         f"ip -6 add add {trafficgen_ip_v6}/64 dev {trafficgen_pf}",
-        ]
+    ]
 
     execute_and_assert(trafficgen, steps, 0, 0.1)
 
@@ -37,7 +37,7 @@ def test_SR_IOV_macAddress_IPv6(dut, trafficgen, settings, testdata):
         f"ip link set {pf} vf 0 mac {vf0_mac}",
         f"ip link set {pf}v0 up",
         f"ip -6 add add {dut_ip_v6}/64 dev {pf}v0",
-        ]
+    ]
 
     execute_and_assert(dut, steps, 0, 0.1)
 

--- a/sriov/tests/SR_IOV_macAddress_IPv6/test_SR_IOV_macAddress_IPv6.py
+++ b/sriov/tests/SR_IOV_macAddress_IPv6/test_SR_IOV_macAddress_IPv6.py
@@ -1,0 +1,45 @@
+from sriov.common.utils import (
+    create_vfs,
+    execute_and_assert,
+    execute_until_timeout,
+)
+
+
+def test_SR_IOV_macAddress_IPv6(dut, trafficgen, settings, testdata):
+    """Test and ensure that VF admin MAC address functions as intended with IPv6
+
+    Args:
+        dut:         ssh connection obj
+        trafficgen:  trafficgen obj
+        settings:    settings obj
+        testdata:    testdata obj
+    """
+
+    trafficgen_ip_v6 = testdata.trafficgen_ip_v6
+    trafficgen_pf = settings.config["trafficgen"]["interface"]["pf1"]["name"]
+    dut_ip_v6 = testdata.dut_ip_v6
+    vf0_mac = testdata.dut_mac
+    pf = settings.config["dut"]["interface"]["pf1"]["name"]
+
+    steps = [
+        f"ip -6 add del {trafficgen_ip_v6}/64 dev {trafficgen_pf} 2>/dev/null || true",
+        f"ip -6 neigh del {dut_ip_v6}  dev {trafficgen_pf} || true",
+        f"ip -6 add add {trafficgen_ip_v6}/64 dev {trafficgen_pf}",
+        ]
+
+    execute_and_assert(trafficgen, steps, 0, 0.1)
+
+    create_vfs(dut, pf, 1)
+
+    steps = [
+        f"ip -6 neigh del {trafficgen_ip_v6} dev {pf} || true",
+        f"ip link set {pf}v0 down",
+        f"ip link set {pf} vf 0 mac {vf0_mac}",
+        f"ip link set {pf}v0 up",
+        f"ip -6 add add {dut_ip_v6}/64 dev {pf}v0",
+        ]
+
+    execute_and_assert(dut, steps, 0, 0.1)
+
+    ping_cmd = "ping -6 -W 1 -c 1 {}".format(testdata.dut_ip_v6)
+    assert execute_until_timeout(trafficgen, ping_cmd)


### PR DESCRIPTION
This test case is verify that IPv6 on an VF works when the VF admin MAC address is explicitly set.