### PR TITLE
Allowing specification of container manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Two ports of the NIC under test are directly connected to the traffic generator 
 On the DUT server, the following RPM packages are required,
 * tmux
 * nmap
-* podman
+* a container manager (podman or docker)
 
 To install,
 ```
@@ -82,6 +82,8 @@ randomly_terminate_test_chance:   # percentage chance to randomly terminate test
                                   # example: 0.5
 randomly_terminate_test_length:   # amount of time, in minutes, to run test_SR_IOV_Randomly_Terminate_DPDK
                                   # example: 10.5
+container_manager:                # the container manager command to use (podman or docker)
+                                  # example: podman
 ```
 
 Running the script from a python3 virtual environment is recommended. Install the required python modules,

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Two ports of the NIC under test are directly connected to the traffic generator 
 On the DUT server, the following RPM packages are required,
 * tmux
 * nmap
-* a container manager (podman or docker)
+* a container manager (podman or docker: The recommendation is to use podman for RHEL)
 
 To install,
 ```
-yum install -y tmux nmap
+yum install -y tmux nmap podman
 ```
 
 On the traffic generator server, the following RPM packages are required,

--- a/sriov/common/configtestdata.py
+++ b/sriov/common/configtestdata.py
@@ -37,11 +37,19 @@ class ConfigTestData:
         vf_pci = settings.config["dut"]["interface"]["vf1"]["pci"]
         dpdk_img = settings.config["dpdk_img"]
         cpus = settings.config["dut"]["pmd_cpus"]
-        self.podman_cmd = (
-            "podman run -it --rm --privileged "
+        self.container_cmd = (
+            f"{settings.config['container_manager']} run -it --rm --privileged "
             "-v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules "
-            "--cpuset-cpus {} {} dpdk-testpmd -l {} -n 4 -a {} "
-            "-- --nb-cores=2 -i".format(cpus, dpdk_img, cpus, vf_pci)
+            f"--cpuset-cpus {cpus} {dpdk_img} dpdk-testpmd -l {cpus} "
+            f"-n 4 -a {vf_pci} "
+            "-- --nb-cores=2 -i"
+        )
+        self.container_cmd_echo = (
+            f"{settings.config['container_manager']} run -it --rm --privileged "
+            "-v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules "
+            f"--cpuset-cpus {cpus} {dpdk_img} dpdk-testpmd -l {cpus} "
+            f"-n 4 -a {vf_pci} "
+            "-- --nb-cores=2 --forward=icmpecho"
         )
         self.ping = {}  # track ping test
         self.mtu = {}  # track mtu change

--- a/sriov/tests/SR_IOV_BondVF_DPDK/test_SR_IOV_BondVF_DPDK.py
+++ b/sriov/tests/SR_IOV_BondVF_DPDK/test_SR_IOV_BondVF_DPDK.py
@@ -72,8 +72,10 @@ def dut_setup(dut, settings, testdata, request) -> Bond:
     if explicit_mac:
         vdev_str = f"{vdev_str},mac={bond_mac}"
 
-    podman_cmd = (
-        "podman run -it --rm --privileged "
+    # The bond container command is specialized, so the testdata based commands
+    # are not used.
+    container_cmd = (
+        f"{settings.config['container_manager']} run -it --rm --privileged "
         "-v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules "
         f"--cpuset-cpus {cpus} {dpdk_img} "
         f"dpdk-testpmd -l {cpus} -n 4 "
@@ -82,9 +84,9 @@ def dut_setup(dut, settings, testdata, request) -> Bond:
         f"-- --forward-mode=mac --portlist {rx_port_num},3 "
         f"--eth-peer 3,{fwd_mac}"
     )
-    dut.log_str(podman_cmd)
+    dut.log_str(container_cmd)
     testpmd_tmux_session = testdata.tmux_session_name
-    assert start_tmux(dut, testpmd_tmux_session, podman_cmd)
+    assert start_tmux(dut, testpmd_tmux_session, container_cmd)
     assert wait_tmux_testpmd_ready(dut, testpmd_tmux_session, 10)
     yield Bond(mode, bond_mac)
     stop_testpmd_in_tmux(dut, testpmd_tmux_session)
@@ -123,14 +125,12 @@ def trafficgen_setup(dut, trafficgen, settings, testdata):
     stop_tmux(trafficgen, ping_tmux_session)
 
 
-bond_setup_params = ({"mode": mode, "mac": mac}
-                     for mode in [0, 1]
-                     for mac in [False, True]
-                     )
+bond_setup_params = (
+    {"mode": mode, "mac": mac} for mode in [0, 1] for mac in [False, True]
+)
 
 
-@pytest.mark.parametrize('dut_setup', bond_setup_params,
-                         indirect=True)
+@pytest.mark.parametrize("dut_setup", bond_setup_params, indirect=True)
 def test_SR_IOV_BondVF_DPDK(
     dut, trafficgen, settings, testdata, dut_setup, trafficgen_setup
 ):
@@ -144,5 +144,6 @@ def test_SR_IOV_BondVF_DPDK(
         dut_setup: dut setup and teardown fixture
         trafficgen_setup: trafficgen setup and teardown fixture
     """
-    validate_bond(dut, trafficgen, settings, testdata,
-                  dut_setup.bond_mode, dut_setup.bond_mac)
+    validate_bond(
+        dut, trafficgen, settings, testdata, dut_setup.bond_mode, dut_setup.bond_mac
+    )

--- a/sriov/tests/SR_IOV_InterVF_DPDK/test_SR_IOV_InterVF_DPDK.py
+++ b/sriov/tests/SR_IOV_InterVF_DPDK/test_SR_IOV_InterVF_DPDK.py
@@ -68,18 +68,9 @@ def test_SR_IOV_InterVF_DPDK(
     assert bind_driver(dut, vf_pci, "vfio-pci")
 
     # start first instance testpmd in echo mode
-    dpdk_img = settings.config["dpdk_img"]
-    cpus = settings.config["dut"]["pmd_cpus"]
-    tmux_cmd = (
-        "podman run -it --rm --privileged "
-        "-v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules "
-        "--cpuset-cpus {} {} dpdk-testpmd -l {} "
-        "-n 4 -a {} "
-        "-- --nb-cores=2 --forward=icmpecho".format(cpus, dpdk_img, cpus, vf_pci)
-    )
-    print(tmux_cmd)
+    print(testdata.container_cmd_echo)
     tmux_session = testdata.tmux_session_name
-    assert start_tmux(dut, tmux_session, tmux_cmd)
+    assert start_tmux(dut, tmux_session, testdata.container_cmd_echo)
 
     # make sure tmux testpmd session has started
     for i in range(15):

--- a/sriov/tests/SR_IOV_Permutation_DPDK/test_SR_IOV_Permutation_DPDK.py
+++ b/sriov/tests/SR_IOV_Permutation_DPDK/test_SR_IOV_Permutation_DPDK.py
@@ -71,7 +71,7 @@ def test_SR_IOV_Permutation_DPDK(
 
     assert verify_vf_address(dut, pf, 0, testdata.dut_mac)
 
-    dut.start_testpmd(testdata.podman_cmd)
+    dut.start_testpmd(testdata.container_cmd)
     assert dut.testpmd_active()
 
     steps = ["set fwd icmpecho", "start"]

--- a/sriov/tests/SR_IOV_RandomlyTerminate_DPDK/test_SR_IOV_RandomlyTerminate_DPDK.py
+++ b/sriov/tests/SR_IOV_RandomlyTerminate_DPDK/test_SR_IOV_RandomlyTerminate_DPDK.py
@@ -14,9 +14,9 @@ from sriov.common.utils import (
 )
 
 
-def get_podman_cmd(name, cpus, dpdk_img, vf_pci):
+def get_container_cmd(container_manager, name, cpus, dpdk_img, vf_pci):
     tmux_cmd = (
-        f"podman run -it --name {name} --rm --privileged "
+        f"{container_manager} run -it --name {name} --rm --privileged "
         "-v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules "
         f"--cpuset-cpus {cpus} {dpdk_img} dpdk-testpmd -l {cpus} "
         f"-n 4 -a {vf_pci} "
@@ -26,11 +26,7 @@ def get_podman_cmd(name, cpus, dpdk_img, vf_pci):
 
 
 def get_testpmd_cpus(control_core, i):
-    cpus = (
-        str(control_core)
-        + ","
-        + str(control_core + i + 1)
-    )
+    cpus = str(control_core) + "," + str(control_core + i + 1)
     return cpus
 
 
@@ -111,7 +107,9 @@ def test_SR_IOV_RandomlyTerminate_DPDK(dut, settings, testdata, options):
 
         cpus = get_testpmd_cpus(settings.config["randomly_terminate_control_core"], i)
         name = base_name + str(i)
-        tmux_cmd = get_podman_cmd(name, cpus, dpdk_img, vf_pci)
+        tmux_cmd = get_container_cmd(
+            settings.config["container_manager"], name, cpus, dpdk_img, vf_pci
+        )
 
         # Start instance of testpmd
         tmux_session = testdata.tmux_session_name + str(i)
@@ -129,14 +127,19 @@ def test_SR_IOV_RandomlyTerminate_DPDK(dut, settings, testdata, options):
                 name = base_name + str(i)
                 tmux_session = tmux_list[i][0]
                 vf_pci = tmux_list[i][1]
-                tmux_cmd = get_podman_cmd(name, cpus, dpdk_img, vf_pci)
+                tmux_cmd = get_container_cmd(
+                    settings.config["container_manager"], name, cpus, dpdk_img, vf_pci
+                )
 
                 # Kill the container
-                steps = [f"podman kill {name}"]
+                steps = [f"{settings.config['container_manager']} kill {name}"]
                 execute_and_assert(dut, steps, 0)
 
                 # Ensure that the container is killed before proceeding
-                steps = f"podman ps -f name={name}$ | grep {name}"
+                steps = (
+                    f"{settings.config['container_manager']} ps -f name={name}$ | "
+                    "grep {name}"
+                )
                 assert execute_until_timeout(dut, steps, 10, 1)
 
                 # Restart the container, as well as rebind drivers if required

--- a/sriov/tests/SR_IOV_macAddress_DPDK/test_SR_IOV_macAddress_DPDK.py
+++ b/sriov/tests/SR_IOV_macAddress_DPDK/test_SR_IOV_macAddress_DPDK.py
@@ -33,16 +33,8 @@ def test_SR_IOV_macAddress_DPDK(dut, trafficgen, settings, testdata):
     vf_pci = get_pci_address(dut, pf + "v0")
     assert bind_driver(dut, vf_pci, "vfio-pci")
 
-    dpdk_img = settings.config["dpdk_img"]
-    cpus = settings.config["dut"]["pmd_cpus"]
-    podman_cmd = (
-        "podman run -it --rm --privileged "
-        "-v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules "
-        "--cpuset-cpus {} {} dpdk-testpmd -l {} -n 4 -a {} "
-        "-- --nb-cores=2 -i".format(cpus, dpdk_img, cpus, vf_pci)
-    )
-    print(podman_cmd)
-    dut.start_testpmd(podman_cmd)
+    print(testdata.container_cmd)
+    dut.start_testpmd(testdata.container_cmd)
     assert dut.testpmd_active()
 
     steps = ["set fwd icmpecho", "start"]

--- a/sriov/tests/common/test_exec.py
+++ b/sriov/tests/common/test_exec.py
@@ -62,13 +62,13 @@ def test_start_and_stop_testpmd(dut, settings):
         dut.log_str(step)
         code, out, err = dut.execute(step)
         assert code == 0, step
-    testpmd_podman_cmd = (
-        "podman run -it --rm --privileged -v /sys:/sys "
-        "-v /dev:/dev -v /lib/modules:/lib/modules "
+    testpmd_container_cmd = (
+        f"{settings.config['container_manager']} run -it --rm --privileged "
+        "-v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules "
         "--cpuset-cpus 30,32,34 docker.io/patrickkutch/dpdk:v21.11 "
         "dpdk-testpmd -l 30,32,34 -n 4 -a " + vf_pci + " -- --nb-cores=2 -i"
     )
-    code, out, err = dut.start_testpmd(testpmd_podman_cmd)
+    code, out, err = dut.start_testpmd(testpmd_container_cmd)
     assert code == 0
     assert dut.testpmd_active()
     assert dut.stop_testpmd() == 0

--- a/sriov/tests/config_template.yaml
+++ b/sriov/tests/config_template.yaml
@@ -6,3 +6,4 @@ randomly_terminate_control_core: 2
 randomly_terminate_max_vfs: 8
 randomly_terminate_test_chance: 0.5
 randomly_terminate_test_length: 10.5
+container_manager: podman


### PR DESCRIPTION
Updating documentation
Updating test files for container_manager field in config Updating testdata specification for container commands NOTE: Some tests still specify their own container commands if they differ heavily from the testdata specified ones, or are only used in a singular test
Updating calls to generic container commands
Formatting

Combined report: https://gist.github.com/dkosteck/520e13f41c9277f72937e19a6f71bd4a
Note: IPv6 test failing