### PR TITLE
Fix extra char issue and add an exec debug flag 

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,8 @@ For example, if some permutation in `SR_IOV_Permutation_DPDK` has failed, re-run
 The test execution will stop immediately without cleaning up, and one may access the DUT and the trafficgen to debug.
 
 After the debug is complete, one has to manually clean up the setup.
+
+## Uncommon options
+
+The following test options are uncommon and meant to use under rare situations:
++ `--debug-execute`: debug command execution over the ssh session

--- a/sriov/common/exec.py
+++ b/sriov/common/exec.py
@@ -6,6 +6,7 @@ from typing import Tuple
 
 
 class ShellHandler:
+    debug_cmd_execute = False
     def __init__(self, host: str, user: str, psw: str, name: str) -> None:
         """Initialize the shell handler object
 
@@ -23,7 +24,7 @@ class ShellHandler:
             self.ssh.connect(host, username=user, port=22)
         else:
             self.ssh.connect(host, username=user, password=psw, port=22)
-        channel = self.ssh.invoke_shell()
+        channel = self.ssh.invoke_shell(width=300)
         self.stdin = channel.makefile("wb")
         self.stdout = channel.makefile("r")
 
@@ -217,17 +218,27 @@ class ShellHandler:
         signal.alarm(timeout)
         try:
             for line in self.stdout:
-                if str(line).startswith(cmd):
+                if ShellHandler.debug_cmd_execute:
+                    print(f"Got line: {repr(line)}")
+                if str(line).endswith(cmd + "\r\n") or str(line).endswith(cmd + "\n"):
                     # up for now filled with shell junk from stdin
+                    if ShellHandler.debug_cmd_execute:
+                        print("reset shout")
                     shout = []
-                elif str(line).startswith(echo_cmd):
+                elif echo_cmd in str(line):
+                    if ShellHandler.debug_cmd_execute:
+                        print("skip line")
                     continue
                 elif str(line).startswith(finish):
                     # our finish command ends with the exit status
                     exit_status = int(str(line).rsplit(maxsplit=1)[1])
+                    if ShellHandler.debug_cmd_execute:
+                        print(f"cmd exit_status: {exit_status}")
                     if exit_status:
                         # stderr is combined with stdout.
                         # thus, swap sherr with shout in a case of failure.
+                        if ShellHandler.debug_cmd_execute:
+                            print("Swap sherr with shout, and reset shout")
                         sherr = shout
                         shout = []
                     break
@@ -239,6 +250,9 @@ class ShellHandler:
                         .replace("\b", "")
                         .replace("\r", "")
                     )
+                if ShellHandler.debug_cmd_execute:
+                    print(f"shout: {shout}")
+                    print(f"sherr: {sherr}")
         except Exception as err:
             exit_status = -1
             sherr.append(str(err))
@@ -248,13 +262,15 @@ class ShellHandler:
         # first and last lines of shout/sherr contain a prompt
         if shout and echo_cmd in shout[-1]:
             shout.pop()
-        if shout and len(shout) > 1 and cmd in shout[0]:
+        if shout and shout[0].endswith(cmd + "\n"):
             shout.pop(0)
         if sherr and echo_cmd in sherr[-1]:
             sherr.pop()
-        if sherr and len(sherr) > 1 and cmd in sherr[0]:
+        if sherr and sherr[0].endswith(cmd + "\n"):
             sherr.pop(0)
-
+        if ShellHandler.debug_cmd_execute:
+            print(f"returning shout: {shout}")
+            print(f"returning sherr: {sherr}")
         return exit_status, shout, sherr
 
     def log_str(self, string: str) -> None:

--- a/sriov/common/exec.py
+++ b/sriov/common/exec.py
@@ -7,6 +7,7 @@ from typing import Tuple
 
 class ShellHandler:
     debug_cmd_execute = False
+
     def __init__(self, host: str, user: str, psw: str, name: str) -> None:
         """Initialize the shell handler object
 

--- a/sriov/tests/conftest.py
+++ b/sriov/tests/conftest.py
@@ -99,6 +99,7 @@ def _cleanup(
 
 
 def pytest_configure(config: Config) -> None:
+    ShellHandler.debug_cmd_execute = config.getoption("--debug-execute")
     dut = get_ssh_obj("dut")
     # Need to clear the terminal before the first command, there may be some
     # residual text from ssh
@@ -231,7 +232,12 @@ def pytest_addoption(parser) -> None:
         default=False,
         help="Do not clean up when a test case fails",
     )
-
+    parser.addoption(
+        "--debug-execute",
+        action="store_true",
+        default=False,
+        help="Debug command execute",
+    )
 
 def pytest_generate_tests(metafunc) -> None:
     if "execution_number" in metafunc.fixturenames:

--- a/sriov/tests/conftest.py
+++ b/sriov/tests/conftest.py
@@ -239,6 +239,7 @@ def pytest_addoption(parser) -> None:
         help="Debug command execute",
     )
 
+
 def pytest_generate_tests(metafunc) -> None:
     if "execution_number" in metafunc.fixturenames:
         if metafunc.config.getoption("iteration"):


### PR DESCRIPTION
The extra char on the command echo line is caused by the default line width 80. Increase it to 200. 

The command  detection is updated, as the original implementation with 'startswith' actually won't match.

To be able to debug this type of exec issues in the future, a debug flag "--debug-execute" is added.

The previous hotfix is backed out as that didn't address the root cause.