### PR TITLE
Stress test updates

### DIFF
--- a/sriov/tests/SR_IOV_RandomlyTerminate_DPDK/README.md
+++ b/sriov/tests/SR_IOV_RandomlyTerminate_DPDK/README.md
@@ -1,6 +1,6 @@
 ## Test Case Name: SR-IOV.RandomlyTerminate.DPDK
 
-### Objective(s): A robustness test to ensure that randomly killed and restarted testpmd containers recover. Permutations are necessary for random termination, random termination with iavf binding, and random termination when resetting the PF.
+### Objective(s): A robustness test to ensure that randomly killed and restarted testpmd containers recover. Permutations are necessary for random termination and random termination with iavf binding.
 
 ### Test procedure
 
@@ -37,7 +37,7 @@ echo ${num_vfs} > /sys/class/net/$PF/device/sriov_numvfs
 
 * Randomly kill containers
 
-* Rebind iavf or reset PF, if required by permutation
+* Rebind iavf, if required by permutation
 
 * Restart containers, checking all are up and transmitting after restart
 

--- a/sriov/tests/SR_IOV_RandomlyTerminate_DPDK/test_SR_IOV_RandomlyTerminate_DPDK.py
+++ b/sriov/tests/SR_IOV_RandomlyTerminate_DPDK/test_SR_IOV_RandomlyTerminate_DPDK.py
@@ -36,8 +36,8 @@ def get_testpmd_cpus(control_core, i):
 @pytest.mark.parametrize("options", (None, "rebind_vf"))
 def test_SR_IOV_RandomlyTerminate_DPDK(dut, settings, testdata, options):
     """A robustness test to ensure that randomly killed and restarted testpmd containers
-       recover. Permutations are necessary for random termination, random termination
-       with iavf binding, and resetting the PF. Adapted from the original pkstress shell
+       recover. Permutations are necessary for random termination and random termination
+       with iavf binding. Adapted from the original pkstress shell
        script written by Patrick Kutch.
 
     Args:


### PR DESCRIPTION
- Moving stopping testpmd in tmux to be in the conftest cleanup (note: this will try to stop up to the maximum specified containers)
- Removing rebind_pf after reported issues
- Updated documentation 
