### PR TITLE
Add switch handling code

### DIFF
--- a/sriov/common/configtestdata.py
+++ b/sriov/common/configtestdata.py
@@ -10,6 +10,8 @@ class ConfigTestData:
             settings (Config): config object
         """
         self.vlan = 10
+        if "vlan" in settings.config:
+            self.vlan = int(settings.config["vlan"])
         self.dut_ip = "101.1.1.2"
         self.dut_ip_v6 = "2001::2"
         self.dut_mac = "aa:bb:cc:dd:ee:00"

--- a/sriov/common/utils.py
+++ b/sriov/common/utils.py
@@ -988,3 +988,10 @@ def delete_ipv6_neighbor(ssh_obj: ShellHandler, ipv6: str):
         return
     cmd = [f"ip -6 neigh del {ipv6} dev {intf}"]
     execute_and_assert(ssh_obj, cmd, 0)
+
+
+def switch_detected(ssh_obj: ShellHandler, interface: str) -> bool:
+    cmd = f"timeout 3 tcpdump -i {interface} -c 1 stp"
+    ssh_obj.log_str(cmd)
+    code, _, _ = ssh_obj.execute(cmd)
+    return code == 0

--- a/sriov/tests/SR_IOV_MTU/README.md
+++ b/sriov/tests/SR_IOV_MTU/README.md
@@ -5,7 +5,7 @@
 
 ### Test procedure
 
-* On DUT, find the maxmtu using `ip -d link list`; do the same on the trafficgen; use the minimum of these two as the common MTU size,
+* On DUT, find the maxmtu using `ip -d link list`; do the same on the trafficgen; use the minimum of these two as the common MTU size. In case a switch sits between the DUT and the trafficgen, a switch MTU can be specified, the minimum of the three will be used as the common MTU size.
 
 * On DUT, create 1 VF with the common MTU; assert 0 exit code on each of the following steps,
 ```

--- a/sriov/tests/SR_IOV_QinQ/test_SR_IOV_QinQ.py
+++ b/sriov/tests/SR_IOV_QinQ/test_SR_IOV_QinQ.py
@@ -12,7 +12,7 @@ def test_SR_IOV_QinQ(dut, trafficgen, settings, testdata):
     """
 
     dut_ip = testdata.dut_ip
-    outside_tag = 10
+    outside_tag = testdata.vlan
     inside_tag = 20
     pf = settings.config["dut"]["interface"]["pf1"]["name"]
 


### PR DESCRIPTION
If switch is used to connect the traffic generator and the DUT, the test script should be flexible to
1) allow the user to provision MTU size via the config.yaml. If a switch is detected, but the MTU is not provisioned, skip the MTU test; if a MTU is specified, use the minimum between the user provisioned MTU, the DUT mtu, trafficgen MTU. If no switch is detected, assume the old direct connection behavior.
2) allow the user to provision vlan tag for all vlan related tests, including the QinQ test, this way multiple test bed can be connected to the same switch. As long as they are using different vlan setting via config.yaml

