### PR TITLE
Fix test_SR_IOV_BondVF_DPDK[dut_setup3] failure #99

### DIFF
--- a/sriov/tests/SR_IOV_BondVF_DPDK/test_SR_IOV_BondVF_DPDK.py
+++ b/sriov/tests/SR_IOV_BondVF_DPDK/test_SR_IOV_BondVF_DPDK.py
@@ -36,9 +36,9 @@ def dut_setup(dut, settings, testdata, request) -> Bond:
     mode = request.param["mode"]
     explicit_mac = request.param["mac"]
     if mode == 1 and explicit_mac:
-        pytest.xfail("Expected failure - mode 1 with explicit bond mac. "
-                     "That should work."
-                     )
+        pytest.xfail(
+            "Expected failure - mode 1 with explicit bond mac. That should work."
+        )
     pf1 = settings.config["dut"]["interface"]["pf1"]["name"]
     assert create_vfs(dut, pf1, 2)
     pf2 = settings.config["dut"]["interface"]["pf2"]["name"]

--- a/sriov/tests/SR_IOV_BondVF_DPDK/test_SR_IOV_BondVF_DPDK.py
+++ b/sriov/tests/SR_IOV_BondVF_DPDK/test_SR_IOV_BondVF_DPDK.py
@@ -35,6 +35,10 @@ def dut_setup(dut, settings, testdata, request) -> Bond:
 
     mode = request.param["mode"]
     explicit_mac = request.param["mac"]
+    if mode == 1 and explicit_mac:
+        pytest.xfail("Expected failure - mode 1 with explicit bond mac. "
+                     "That should work."
+                     )
     pf1 = settings.config["dut"]["interface"]["pf1"]["name"]
     assert create_vfs(dut, pf1, 2)
     pf2 = settings.config["dut"]["interface"]["pf2"]["name"]


### PR DESCRIPTION
We need to resolve a failure is test_SR_IOV_BondVF_DPDK[dut_setup3] #99 . It is currently reproducible with the latest in-tree and OOT drivers. Current fix just conforms to bond behaviour. Please review and advise if there is a better way to fix it.

 (venv) [akiselev@akiselev-x1c tests]$ pytest -v --html=report87oot_BondVF.html --self-contained-html SR_IOV_BondVF_DPDK/
clear
uname -r
ethtool -i ens4f0
cat /sys/bus/pci/drivers/iavf/module/version
============================================================================== test session starts ==============================================================================
platform linux -- Python 3.11.1, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /home/akiselev/intel-sriov-test/venv/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.11.1', 'Platform': 'Linux-6.1.10-200.fc37.x86_64-x86_64-with-glibc2.36', 'Packages': {'pytest': '6.2.5', 'pluggy': '1.0.0'}, 'Plugins': {'metadata': '2.0.4', 'html': '3.2.0'}, 'DUT Kernel': '4.18.0-425.10.1.rt7.220.el8_7.x86_64', 'NIC Driver': 'ice\n 1.10.1.2.2\n', 'NIC Firmware': '4.10', 'IAVF Driver': '4.18.0-425.10.1.rt7.220.el8_7.x86_64'}
rootdir: /home/akiselev/intel-sriov-test/sriov/tests
plugins: metadata-2.0.4, html-3.2.0
collected 4 items                                                                                                                                                               

SR_IOV_BondVF_DPDK/test_SR_IOV_BondVF_DPDK.py::test_SR_IOV_BondVF_DPDK[dut_setup0] PASSED                                                                                 [ 25%]
SR_IOV_BondVF_DPDK/test_SR_IOV_BondVF_DPDK.py::test_SR_IOV_BondVF_DPDK[dut_setup1] PASSED                                                                                 [ 50%]
SR_IOV_BondVF_DPDK/test_SR_IOV_BondVF_DPDK.py::test_SR_IOV_BondVF_DPDK[dut_setup2] PASSED                                                                                 [ 75%]
SR_IOV_BondVF_DPDK/test_SR_IOV_BondVF_DPDK.py::test_SR_IOV_BondVF_DPDK[dut_setup3] PASSED                                                                                 [100%]

---------------------------------------- generated html file: file:///home/akiselev/intel-sriov-test/sriov/tests/report87oot_BondVF.html ----------------------------------------
========================================================================= 4 passed in 103.73s (0:01:43) =========================================================================
(venv) [akiselev@akiselev-x1c tests]$ 
