### PR TITLE
Fix XXV710 bonding test failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ container_manager:                # the container manager command to use (podman
                                   # example: podman
 vlan:                             # vlan tag used by the vlan tests, default is 10
 mtu:                              # MTU size; if unspecified, the script will derive it
+bonding_switch_delay              # Expected bonding switch over/back delay in second, default is 1
 ```
 
 Running the script from a python3 virtual environment is recommended. Install the required python modules,

--- a/sriov/common/macros.py
+++ b/sriov/common/macros.py
@@ -5,10 +5,9 @@ functions.
 For example, common test steps that involve test case specific asserts and are shared
 between multiple test cases may be good candidate for this file.
 """
-
+import time
 from sriov.common.utils import (
     execute_and_assert,
-    verify_vf_address,
 )
 
 
@@ -34,7 +33,10 @@ def validate_bond(
         bond_mac: mac address for bond interface
     """
     pf1 = settings.config["dut"]["interface"]["pf1"]["name"]
-    pf2 = settings.config["dut"]["interface"]["pf2"]["name"]
+    bonding_switch_delay = 1
+    if "bonding_switch_delay" in settings.config:
+        bonding_switch_delay = int(settings.config["bonding_switch_delay"])
+    # pf2 = settings.config["dut"]["interface"]["pf2"]["name"]
     trafficgen_pf1 = settings.config["trafficgen"]["interface"]["pf1"]["name"]
     trafficgen_pf2 = settings.config["trafficgen"]["interface"]["pf2"]["name"]
     fwd_mac = testdata.trafficgen_spoof_mac
@@ -50,7 +52,11 @@ def validate_bond(
         # shut down the VF only if it is bond mode 1
         link_down_cmd = f"ip link set {pf1} vf 0 state disable"
         execute_and_assert(dut, [link_down_cmd], 0)
-    assert verify_vf_address(dut, pf2, 0, bond_mac, interval=1)
+
+    # wait for switch over happen
+    time.sleep(bonding_switch_delay)
+    # Remove the following line because XXV710 has different behavor than E810
+    # assert verify_vf_address(dut, pf2, 0, bond_mac, interval=1)
     # traffic should switch over to the backup VF
     tcpdump_cmd = (
         f"timeout 3 tcpdump -i {trafficgen_pf2} -c 1 "
@@ -64,7 +70,10 @@ def validate_bond(
         # switch back only for bond mode 1
         link_up_cmd = f"ip link set {pf1} vf 0 state enable"
         execute_and_assert(dut, [link_up_cmd], 0)
-        assert verify_vf_address(dut, pf1, 0, bond_mac, interval=1)
+        # wait for switch back happen
+        time.sleep(bonding_switch_delay)
+        # Remove the following line because XXV710 has different behavor than E810
+        # assert verify_vf_address(dut, pf1, 0, bond_mac, interval=1)
         tcpdump_cmd = (
             f"timeout 3 tcpdump -i {trafficgen_pf1} -c 1 "
             f"ether src {bond_mac} and ether dst {fwd_mac}"

--- a/sriov/tests/config_template.yaml
+++ b/sriov/tests/config_template.yaml
@@ -9,3 +9,4 @@ randomly_terminate_test_length: 10.5
 container_manager: podman
 vlan: 10
 mtu: 1500
+bonding_switch_delay: 5


### PR DESCRIPTION
This PR is to fix the bonding test failure caused by xxv710 due to its behavior difference from E810.

The first difference is: xxv710 VF mac address is not updated to the bond interface mac address when put in the bond interface. There is no specification that requires  the VF mac address must update, so the VF mac address check  that was put into place for E810 is removed.

The xxv710 appears to take longer time to complete the switch over or the switch back process when the primary link status is changed. To address this, a delay is introduced after changing the primary link state.
