### PR TITLE
Add mtu and vlan settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ randomly_terminate_test_length:   # amount of time, in minutes, to run test_SR_I
                                   # example: 10.5
 container_manager:                # the container manager command to use (podman or docker)
                                   # example: podman
+vlan:                             # vlan tag used by the vlan tests, default is 10
+mtu:                              # MTU size; if unspecified, the script will derive it
 ```
 
 Running the script from a python3 virtual environment is recommended. Install the required python modules,
@@ -174,3 +176,4 @@ After the debug is complete, one has to manually clean up the setup.
 
 The following test options are uncommon and meant to use under rare situations:
 + `--debug-execute`: debug command execution over the ssh session
+

--- a/sriov/common/configtestdata.py
+++ b/sriov/common/configtestdata.py
@@ -10,6 +10,8 @@ class ConfigTestData:
             settings (Config): config object
         """
         self.vlan = 10
+        if "vlan" in settings.config:
+            self.vlan = int(settings.config["vlan"])
         self.dut_ip = "101.1.1.2"
         self.dut_ip_v6 = "2001::2"
         self.dut_mac = "aa:bb:cc:dd:ee:00"

--- a/sriov/common/utils.py
+++ b/sriov/common/utils.py
@@ -988,3 +988,10 @@ def delete_ipv6_neighbor(ssh_obj: ShellHandler, ipv6: str):
         return
     cmd = [f"ip -6 neigh del {ipv6} dev {intf}"]
     execute_and_assert(ssh_obj, cmd, 0)
+
+
+def switch_detected(ssh_obj: ShellHandler, interface: str) -> bool:
+    cmd = f"timeout 3 tcpdump -i {interface} -c 1 stp"
+    ssh_obj.log_str(cmd)
+    code, _, _ = ssh_obj.execute(cmd)
+    return code == 0

--- a/sriov/tests/SR_IOV_MTU/README.md
+++ b/sriov/tests/SR_IOV_MTU/README.md
@@ -5,7 +5,7 @@
 
 ### Test procedure
 
-* On DUT, find the maxmtu using `ip -d link list`; do the same on the trafficgen; use the minimum of these two as the common MTU size,
+* On DUT, find the maxmtu using `ip -d link list`; do the same on the trafficgen; use the minimum of these two as the common MTU size. If a MTU is specified via settings, the minimum of the three will be used as the common MTU size.
 
 * On DUT, create 1 VF with the common MTU; assert 0 exit code on each of the following steps,
 ```

--- a/sriov/tests/SR_IOV_QinQ/test_SR_IOV_QinQ.py
+++ b/sriov/tests/SR_IOV_QinQ/test_SR_IOV_QinQ.py
@@ -12,7 +12,7 @@ def test_SR_IOV_QinQ(dut, trafficgen, settings, testdata):
     """
 
     dut_ip = testdata.dut_ip
-    outside_tag = 10
+    outside_tag = testdata.vlan
     inside_tag = 20
     pf = settings.config["dut"]["interface"]["pf1"]["name"]
 

--- a/sriov/tests/config_template.yaml
+++ b/sriov/tests/config_template.yaml
@@ -7,3 +7,5 @@ randomly_terminate_max_vfs: 8
 randomly_terminate_test_chance: 0.5
 randomly_terminate_test_length: 10.5
 container_manager: podman
+vlan: 10
+mtu: 1500


### PR DESCRIPTION
This PR is to add vlan and MTU setting via config.yaml.

They both have their default setting is not explicitly configured.

The default value of vlan is 10.

The default MTU is the minimum value between the trafficgen interface MTU and the DUT interface MTU. With an explicit MTU setting, the minimum of the three. 