### PR TITLE
Add SR_IOV_OVS_IPv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To install,
 yum install -y tmux nmap podman
 ```
 
-One special test case, SR_IOV_OVS_IPv6, requires openvswitch. Without openvswitch installed, this test case will be skipped. To install an up to date openvswitch, install from the openvswitch source tree is recommended. Alternatively, an out of date  openvswitch version can be installed on RHEL just for the testing purpose,
+One special test case, SR_IOV_OVS_IPv6, requires Open vSwitch. Without Open vSwitch installed, this test case will be skipped. To install an up to date Open vSwitch, install from the source tree is recommended. Alternatively, an out of date Open vSwitch version can be installed on RHEL just for the testing purpose,
 ```
 yum install -y https://rdoproject.org/repos/rdo-release.rpm
 yum install -y openvswitch

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ To install,
 yum install -y tmux nmap podman
 ```
 
+One special test case, SR_IOV_OVS_IPv6, requires openvswitch. Without openvswitch installed, this test case will be skipped. To install openvswitch on RHEL 8,
+```
+subscription-manager repos --enable "rhel-8-for-x86_64-appstream-rpms"
+yum install -y openvswitch
+```
+
 On the traffic generator server, the following RPM packages are required,
 * nmap
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ To install,
 yum install -y tmux nmap podman
 ```
 
-One special test case, SR_IOV_OVS_IPv6, requires openvswitch. Without openvswitch installed, this test case will be skipped. To install openvswitch on RHEL 8,
+One special test case, SR_IOV_OVS_IPv6, requires openvswitch. Without openvswitch installed, this test case will be skipped. To install an up to date openvswitch, install from the openvswitch source tree is recommended. Alternatively, an out of date  openvswitch version can be installed on RHEL just for the testing purpose,
 ```
-subscription-manager repos --enable "rhel-8-for-x86_64-appstream-rpms"
+yum install -y https://rdoproject.org/repos/rdo-release.rpm
 yum install -y openvswitch
 ```
 

--- a/sriov/common/utils.py
+++ b/sriov/common/utils.py
@@ -991,7 +991,32 @@ def delete_ipv6_neighbor(ssh_obj: ShellHandler, ipv6: str):
 
 
 def switch_detected(ssh_obj: ShellHandler, interface: str) -> bool:
+    """Test if the specified interface is connected to a switch
+
+    Args:
+        ssh_obj (ShellHandler): ssh connection obj
+        interface (str): interface name
+
+    Returns:
+        bool: True is a switch is detected
+    """
     cmd = f"timeout 3 tcpdump -i {interface} -c 1 stp"
+    ssh_obj.log_str(cmd)
+    code, _, _ = ssh_obj.execute(cmd)
+    return code == 0
+
+
+def is_package_installed(ssh_obj: ShellHandler, package_name) -> bool:
+    """Test if the specified RPM package is installed
+
+    Args:
+        ssh_obj (ShellHandler): ssh connection obj
+        package_name (str): RPM package name
+
+    Returns:
+        bool: True if the package is installed
+    """
+    cmd = f"rpm -q {package_name}"
     ssh_obj.log_str(cmd)
     code, _, _ = ssh_obj.execute(cmd)
     return code == 0

--- a/sriov/tests/SR_IOV_OVS_IPv6/README.md
+++ b/sriov/tests/SR_IOV_OVS_IPv6/README.md
@@ -1,11 +1,11 @@
 
 ## Test Case Name: SR-IOV.OVS.IPv6
 
-### Objective(s): Test and ensure IPv6 address on a VF can have the same host suffix as an openvswitch virtual port on the same PF (https://bugzilla.redhat.com/show_bug.cgi?id=2138215)  
+### Objective(s): Test and ensure IPv6 address on a VF can have the same host suffix as an Open vSwitch virtual port on the same PF (https://bugzilla.redhat.com/show_bug.cgi?id=2138215)  
 
 ### Test procedure
 
-* Let "vif_vlan" be the vlan for the virtual interface, "pf" be the physical interface name that the virtual interface will be created on, and "dut_vif_ipv6" be the IPv6 address that is assigned to the virtual interface. On DUT, Assert on 0 exit code of each of the following steps,
+* Let "vif_vlan" be the VLAN for the virtual interface, "pf" be the physical interface name that the virtual interface will be created on, and "dut_vif_ipv6" be the IPv6 address that is assigned to the virtual interface. On DUT, Assert on 0 exit code of each of the following steps,
 ```
 systemctl start openvswitch,
 ip link del ${pf}.${vif_vlan},
@@ -18,7 +18,7 @@ ip -6 addr add ${dut_vif_ipv6}/64 dev ovs-br0,
 ip link set ovs-br0 up,
 ```
 
-* On the trafficgen, create a virual interface with vlan "vif_vlan" on trafficgen_pf, and assign an IPv6 address "trafficgen_ipv6" to this virtual interface,
+* On the trafficgen, create a virual interface with VLAN "vif_vlan" on "trafficgen_pf", and assign an IPv6 address "trafficgen_ipv6" to this virtual interface,
 ```
 ip link add link ${trafficgen_pf} name ${trafficgen_pf}.${vif_vlan} type vlan id ${vif_vlan}
 ip -6 addr add ${trafficgen_ipv6}/64 dev ${trafficgen_pf}.${vif_vlan}
@@ -30,7 +30,7 @@ ip link set ${trafficgen_pf}.${vif_vlan} up
 ping -W 1 -c 1 {dut_vif_ipv6}
 ```
 
-* Create 1 VF on the DUT, set this VF's vlan to "vf_vlan" (a different vlan than "vif_vlan"), assign an IPv6 address "dut_vf_ipv6" from a different network but with the same host suffix as the "dut_vif_ipv6",
+* Create 1 VF on the DUT, set this VF's VLAN to "vf_vlan" (a different VLAN than "vif_vlan"), assign an IPv6 address "dut_vf_ipv6" from a different network but with the same host suffix as the "dut_vif_ipv6",
 ```
 echo 0 > /sys/class/net/${pf}/device/sriov_numvfs
 echo 1 > /sys/class/net/${pf}/device/sriov_numvfs
@@ -42,12 +42,6 @@ ip add add ${dut_vf_ipv6}/64 dev ${pf}v0
 * On trafficgen, delete the existing IPv6 neighbor entry for "dut_vif_ipv6", repeat the same ping test (success last time before the VF is created and assign the IPv6 address). Expect the ping to fail this time, due to (https://bugzilla.redhat.com/show_bug.cgi?id=2138215).
 ```
 ping -W 1 -c 1 {dut_vif_ipv6}
-```
-
-* On trafficgen, remove arp entry and ip address,
-```
-arp -d ${DUT_IP}
-ip addr del ${TGEN_IP}/24 dev ${TGEN_PF}
 ```
 
 ### Clean up

--- a/sriov/tests/SR_IOV_OVS_IPv6/README.md
+++ b/sriov/tests/SR_IOV_OVS_IPv6/README.md
@@ -1,0 +1,68 @@
+
+## Test Case Name: SR-IOV.OVS.IPv6
+
+### Objective(s): Test and ensure IPv6 address on a VF can have the same host suffix as an openvswitch virtual port on the same PF (https://bugzilla.redhat.com/show_bug.cgi?id=2138215)  
+
+### Test procedure
+
+* Let "vif_vlan" be the vlan for the virtual interface, "pf" be the physical interface name that the virtual interface will be created on, and "dut_vif_ipv6" be the IPv6 address that is assigned to the virtual interface. On DUT, Assert on 0 exit code of each of the following steps,
+```
+systemctl start openvswitch,
+ip link del ${pf}.${vif_vlan},
+ip link add link ${pf} name ${pf}.${vif_vlan} type vlan id ${vif_vlan},
+ip link set ${pf}.${vif_vlan} up,
+ovs-vsctl del-br ovs-br0,
+ovs-vsctl add-br ovs-br0,
+ovs-vsctl add-port ovs-br0 ${pf}.${vif_vlan},
+ip -6 addr add ${dut_vif_ipv6}/64 dev ovs-br0,
+ip link set ovs-br0 up,
+```
+
+* On the trafficgen, create a virual interface with vlan "vif_vlan" on trafficgen_pf, and assign an IPv6 address "trafficgen_ipv6" to this virtual interface,
+```
+ip link add link ${trafficgen_pf} name ${trafficgen_pf}.${vif_vlan} type vlan id ${vif_vlan}
+ip -6 addr add ${trafficgen_ipv6}/64 dev ${trafficgen_pf}.${vif_vlan}
+ip link set ${trafficgen_pf}.${vif_vlan} up
+```
+
+* On the trafficgen, assert ping success to dut_vif_ipv6,
+```
+ping -W 1 -c 1 {dut_vif_ipv6}
+```
+
+* Create 1 VF on the DUT, set this VF's vlan to "vf_vlan" (a different vlan than "vif_vlan"), assign an IPv6 address "dut_vf_ipv6" from a different network but with the same host suffix as the "dut_vif_ipv6",
+```
+echo 0 > /sys/class/net/${pf}/device/sriov_numvfs
+echo 1 > /sys/class/net/${pf}/device/sriov_numvfs
+ip link set ${pf} vf 0 vlan ${vf_vlan}
+ip link set ${pf}v0 up
+ip add add ${dut_vf_ipv6}/64 dev ${pf}v0
+```
+
+* On trafficgen, delete the existing IPv6 neighbor entry for "dut_vif_ipv6", repeat the same ping test (success last time before the VF is created and assign the IPv6 address). Expect the ping to fail this time, due to (https://bugzilla.redhat.com/show_bug.cgi?id=2138215).
+```
+ping -W 1 -c 1 {dut_vif_ipv6}
+```
+
+* On trafficgen, remove arp entry and ip address,
+```
+arp -d ${DUT_IP}
+ip addr del ${TGEN_IP}/24 dev ${TGEN_PF}
+```
+
+### Clean up
+
+* On DUT,
+```
+ovs-vsctl del-port ovs-br0 ${pf}.${vif_vlan}
+ovs-vsctl del-br ovs-br0
+ip link del ${pf}.${vif_vlan}
+systemctl stop openvswitch
+echo 0 > /sys/class/net/${pf}/device/sriov_numvfs
+```
+
+* On trafficgen,
+```
+ip link del ${trafficgen_pf}.${vif_vlan}
+```
+

--- a/sriov/tests/SR_IOV_OVS_IPv6/test_SR_IOV_OVS_IPv6.py
+++ b/sriov/tests/SR_IOV_OVS_IPv6/test_SR_IOV_OVS_IPv6.py
@@ -11,7 +11,7 @@ from sriov.common.utils import (
 
 dut_vif_ipv6 = "2001:1b74:4d9:1002::4"
 trafficgen_ipv6 = "2001:1b74:4d9:1002::5"
-# VF ip has different network portion as the VIF, but same host portion
+# VF IPv6 has different network portion as the VIF, but same host portion
 dut_vf_ipv6 = "2001:1b74:4d9:1003::4"
 
 
@@ -54,7 +54,7 @@ def ovs_setup(dut, trafficgen, settings, testdata):
 def test_SR_IOV_OVS_IPv6(
     dut, trafficgen, settings, testdata, ovs_setup
 ):
-    """Test IPv6 on a VF sharing the same PF with a openvswitch virtual port
+    """Test IPv6 on a VF sharing the same PF with a Open vSwitch virtual port
 
     Args:
         dut:         ssh connection obj
@@ -72,7 +72,7 @@ def test_SR_IOV_OVS_IPv6(
 
     create_vfs(dut, pf, 1)
 
-    # VF vlan is not important
+    # VF VLAN is not important
     vf_vlan = testdata.vlan + 1
     steps = [
         f"ip link set {pf}v0 down",

--- a/sriov/tests/SR_IOV_OVS_IPv6/test_SR_IOV_OVS_IPv6.py
+++ b/sriov/tests/SR_IOV_OVS_IPv6/test_SR_IOV_OVS_IPv6.py
@@ -1,0 +1,85 @@
+import pytest
+from sriov.common.utils import (
+    create_vfs,
+    execute_and_assert,
+    execute_until_timeout,
+    delete_ipv6_neighbor,
+    prepare_ping_ipv6_test,
+    is_package_installed,
+)
+
+
+dut_vif_ipv6 = "2001:1b74:4d9:1002::4"
+trafficgen_ipv6 = "2001:1b74:4d9:1002::5"
+# VF ip has different network portion as the VIF, but same host portion
+dut_vf_ipv6 = "2001:1b74:4d9:1003::4"
+
+
+@pytest.fixture
+def ovs_setup(dut, trafficgen, settings, testdata):
+    if not is_package_installed(dut, "openvswitch"):
+        pytest.skip("OVS package not installed")
+
+    pf = settings.config["dut"]["interface"]["pf1"]["name"]
+    vif_vlan = testdata.vlan
+
+    delete_ipv6_neighbor(dut, trafficgen_ipv6)
+    delete_ipv6_neighbor(trafficgen, dut_vif_ipv6)
+
+    du_steps = [
+        "systemctl start openvswitch",
+        f"ip link del {pf}.{vif_vlan} || true",
+        f"ip link add link {pf} name {pf}.{vif_vlan} type vlan id {vif_vlan}",
+        f"ip link set {pf}.{vif_vlan} up",
+        "ovs-vsctl del-br ovs-br0 || true",
+        "ovs-vsctl add-br ovs-br0 || true",
+        f"ovs-vsctl add-port ovs-br0 {pf}.{vif_vlan}",
+        f"ip -6 addr add {dut_vif_ipv6}/64 dev ovs-br0",
+        "ip link set ovs-br0 up",
+    ]
+    execute_and_assert(dut, du_steps, 0, 0.1)
+
+    yield
+
+    du_cleanups = [
+        f"ovs-vsctl del-port ovs-br0 {pf}.{vif_vlan}",
+        "ovs-vsctl del-br ovs-br0",
+        f"ip link del {pf}.{vif_vlan}",
+        "systemctl stop openvswitch",
+    ]
+    execute_and_assert(dut, du_cleanups, 0, 0.1)
+
+
+@pytest.mark.xfail(reason="https://bugzilla.redhat.com/show_bug.cgi?id=2138215")
+def test_SR_IOV_OVS_IPv6(
+    dut, trafficgen, settings, testdata, ovs_setup
+):
+    """Test IPv6 on a VF sharing the same PF with a openvswitch virtual port
+
+    Args:
+        dut:         ssh connection obj
+        trafficgen:  trafficgen obj
+        settings:    settings obj
+        testdata:    testdata obj
+    """
+    pf = settings.config["dut"]["interface"]["pf1"]["name"]
+    trafficgen_pf = settings.config["trafficgen"]["interface"]["pf1"]["name"]
+
+    prepare_ping_ipv6_test(trafficgen, trafficgen_pf, testdata.vlan,
+                           trafficgen_ipv6, dut_vif_ipv6, testdata)
+
+    assert execute_until_timeout(trafficgen, f"ping -W 1 -c 1 {dut_vif_ipv6}")
+
+    create_vfs(dut, pf, 1)
+
+    # VF vlan is not important
+    vf_vlan = testdata.vlan + 1
+    steps = [
+        f"ip link set {pf}v0 down",
+        f"ip link set {pf} vf 0 vlan {vf_vlan}",
+        f"ip -6 addr add {dut_vf_ipv6}/64 dev {pf}v0",
+        f"ip link set {pf}v0 up",
+    ]
+    execute_and_assert(dut, steps, 0, 0.1)
+    delete_ipv6_neighbor(trafficgen, dut_vif_ipv6)
+    assert execute_until_timeout(trafficgen, f"ping -W 1 -c 1 {dut_vif_ipv6}")


### PR DESCRIPTION
This is a triage test case coverage for https://bugzilla.redhat.com/show_bug.cgi?id=2138215.

This test case has dependency on openvswitch, so READme is updated with this openvswitch install requirement.

Due to the triage coverage nature, this test case is not a must run (comparing to other test cases) - if openvswitch is not pre-installed, this test case will be skipped.

Here is how it looks when openvswitch is not installed:
```
(venv) [jianzzha@jianzzha tests]$ pytest -v -rx SR_IOV_OVS_IPv6
clear
uname -r
ethtool -i ens7f0
cat /sys/bus/pci/drivers/iavf/module/version
================================================= test session starts ==================================================
platform linux -- Python 3.6.7, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /home/jianzzha/intel-sriov-test/sriov/tests/venv/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.7', 'Platform': 'Linux-3.10.0-1160.66.1.el7.x86_64-x86_64-with-redhat-7.9-Maipo', 'Packages': {'pytest': '6.2.5', 'py': '1.11.0', 'pluggy': '1.0.0'}, 'Plugins': {'metadata': '1.11.0', 'html': '3.2.0'}, 'DUT Kernel': '4.18.0-425.10.1.rt7.220.el8_7.x86_64', 'NIC Driver': 'i40e\n 4.18.0-425.10.1.rt7.220.el8_7.x\n', 'NIC Firmware': '7.10', 'IAVF Driver': '4.18.0-425.10.1.rt7.220.el8_7.x86_64'}
rootdir: /home/jianzzha/intel-sriov-test/sriov/tests
plugins: metadata-1.11.0, html-3.2.0
collected 1 item                                                                                                       

SR_IOV_OVS_IPv6/test_SR_IOV_OVS_IPv6.py::test_SR_IOV_OVS_IPv6 SKIPPED (OVS package not installed)                [100%]

=================================================== warnings summary ===================================================
venv/lib64/python3.6/site-packages/paramiko/transport.py:33
  /home/jianzzha/intel-sriov-test/sriov/tests/venv/lib64/python3.6/site-packages/paramiko/transport.py:33: CryptographyDeprecationWarning: Python 3.6 is no longer supported by the Python core team. Therefore, support for it is deprecated in cryptography. The next release of cryptography (40.0) will be the last to support Python 3.6.
    from cryptography.hazmat.backends import default_backend

-- Docs: https://docs.pytest.org/en/stable/warnings.html
============================================ 1 skipped, 1 warning in 7.14s =============================================

```

Here is how it looks with the xfail,
```
(venv) [jianzzha@jianzzha tests]$ pytest -v -rx SR_IOV_OVS_IPv6
clear
uname -r
ethtool -i ens2f0
cat /sys/bus/pci/drivers/iavf/module/version
================================================= test session starts ==================================================
platform linux -- Python 3.6.7, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /home/jianzzha/intel-sriov-test/sriov/tests/venv/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.6.7', 'Platform': 'Linux-3.10.0-1160.66.1.el7.x86_64-x86_64-with-redhat-7.9-Maipo', 'Packages': {'pytest': '6.2.5', 'py': '1.11.0', 'pluggy': '1.0.0'}, 'Plugins': {'metadata': '1.11.0', 'html': '3.2.0'}, 'DUT Kernel': '4.18.0-372.32.1.el8_6.x86_64', 'NIC Driver': 'ice\n 1.9.11\n', 'NIC Firmware': '4.10', 'IAVF Driver': '4.18.0-372.32.1.el8_6.x86_64'}
rootdir: /home/jianzzha/intel-sriov-test/sriov/tests
plugins: metadata-1.11.0, html-3.2.0
collected 1 item                                                                                                       

SR_IOV_OVS_IPv6/test_SR_IOV_OVS_IPv6.py::test_SR_IOV_OVS_IPv6 XFAIL (https://bugzilla.redhat.com/show_bug.cg...) [100%]

=================================================== warnings summary ===================================================
venv/lib64/python3.6/site-packages/paramiko/transport.py:33
  /home/jianzzha/intel-sriov-test/sriov/tests/venv/lib64/python3.6/site-packages/paramiko/transport.py:33: CryptographyDeprecationWarning: Python 3.6 is no longer supported by the Python core team. Therefore, support for it is deprecated in cryptography. The next release of cryptography (40.0) will be the last to support Python 3.6.
    from cryptography.hazmat.backends import default_backend

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=============================================== short test summary info ================================================
XFAIL SR_IOV_OVS_IPv6/test_SR_IOV_OVS_IPv6.py::test_SR_IOV_OVS_IPv6
  https://bugzilla.redhat.com/show_bug.cgi?id=2138215
============================================ 1 xfailed, 1 warning in 37.03s ============================================

```


