### PR TITLE
Change ci actions to run on pull-request and update setup-python version

### DIFF
--- a/.github/workflows/github-actions.yaml
+++ b/.github/workflows/github-actions.yaml
@@ -1,5 +1,5 @@
 name: GitHub Actions mock test
-on: [push]
+on: [pull_request]
 jobs:
   GitHub-Actions-mock-test:
     runs-on: ubuntu-latest
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
       - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -20,4 +20,5 @@ jobs:
         pip install flake8
     - name: Lint with flake8
       run: |
-        flake8 sriov --count --select=E --max-complexity=20 --max-line-length=88 --show-source --statistics
+        flake8 sriov --count --select=E --max-complexity=20 --max-line-length=88 --show-source \
+        --statistics 

--- a/sriov/tests/conftest.py
+++ b/sriov/tests/conftest.py
@@ -32,7 +32,8 @@ def get_ssh_obj(name: str) -> ShellHandler:
     retObj = None
     try:
         retObj = ShellHandler(host, user, password, name)
-    except: #error caught and printed in ShellHandler
+    except Exception:
+        # error caught and printed in ShellHandler
         pass
 
     return retObj
@@ -50,7 +51,7 @@ def settings() -> Config:
 @pytest.fixture
 def dut() -> ShellHandler:
     dut_obj = get_ssh_obj("dut")
-    assert(dut_obj)
+    assert (dut_obj)
     assert set_pipefail(dut_obj)
     return dut_obj
 
@@ -77,7 +78,7 @@ def reset_command(dut: ShellHandler, testdata) -> None:
 @pytest.fixture
 def trafficgen() -> ShellHandler:
     trafficgen_obj = get_ssh_obj("trafficgen")
-    assert(trafficgen_obj)
+    assert (trafficgen_obj)
 
     assert set_pipefail(trafficgen_obj)
     return trafficgen_obj
@@ -128,7 +129,7 @@ def _cleanup(
 def pytest_configure(config: Config) -> None:
     ShellHandler.debug_cmd_execute = config.getoption("--debug-execute")
     dut = get_ssh_obj("dut")
-    assert(dut)
+    assert (dut)
     # Need to clear the terminal before the first command, there may be some
     # residual text from ssh
     cmd_clear = "clear"


### PR DESCRIPTION
We need to have all actions to run on pull_request. Plus, update setup-python to v4.
That will avoid "depricated" warning we have currently on every CI run.
This PR includes re-factoring of conftest.py to have a clean lint run.