### PR TITLE
Select missing violation classes in flake8

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,5 +20,5 @@ jobs:
         pip install flake8
     - name: Lint with flake8
       run: |
-        flake8 sriov --count -select=E,C,F,W --ignore W503 --max-complexity=15 \
+        flake8 sriov --count --select=E,C,F,W --ignore W503 --max-complexity=15 \
         --max-line-length=88 --show-source --statistics 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,5 +20,5 @@ jobs:
         pip install flake8
     - name: Lint with flake8
       run: |
-        flake8 sriov --count --select=E --max-complexity=20 --max-line-length=88 --show-source \
-        --statistics 
+        flake8 sriov --count -select=E,C,F,W --ignore W503 --max-complexity=15 \
+        --max-line-length=88 --show-source --statistics 

--- a/sriov/common/exec.py
+++ b/sriov/common/exec.py
@@ -27,7 +27,7 @@ class ShellHandler:
             else:
                 self.ssh.connect(host, username=user, password=psw, port=22)
 
-        except paramiko.AuthenticationException as Ex:
+        except paramiko.AuthenticationException:
             print("ERROR: invalid credentials provided for {}".format(host))
             raise
 
@@ -198,7 +198,8 @@ class ShellHandler:
 
         return exit_code
 
-    def execute(self, cmd: str, timeout: int = 5) -> Tuple[int, list, list]:
+    def execute(self, cmd: str, timeout: int = 5) \
+            -> Tuple[int, list, list]:  # noqa: C901
         """Execute a command in the SSH session
 
         Args:


### PR DESCRIPTION
Once we start using --select in flake8, it needs to be used for all violation classes. Plus, reverting max-complexity back to 15 with one exception.