### PR TITLE
Hotfix for timeout common test

### DIFF
--- a/sriov/tests/common/test_exec.py
+++ b/sriov/tests/common/test_exec.py
@@ -35,7 +35,7 @@ def test_execute_cmd_timeout(dut):
     dut.log_str(cmd)
     code, out, err = dut.execute(cmd)
     # Allow for original sleep to end (5 second timeout + 1 second) before cleanup
-    time.sleep(1)
+    time.sleep(1.5)
     assert code != 0 and "timeout" in err[0]
 
 

--- a/sriov/tests/common/test_exec.py
+++ b/sriov/tests/common/test_exec.py
@@ -31,9 +31,11 @@ def test_execute_cmd_fail(dut):
 
 
 def test_execute_cmd_timeout(dut):
-    cmd = "sleep 10s"
+    cmd = "sleep 6s"
     dut.log_str(cmd)
     code, out, err = dut.execute(cmd)
+    # Allow for original sleep to end (5 second timeout + 1 second) before cleanup
+    time.sleep(1)
     assert code != 0 and "timeout" in err[0]
 
 

--- a/sriov/tests/common/test_utils.py
+++ b/sriov/tests/common/test_utils.py
@@ -91,8 +91,9 @@ def test_config_and_clear_interface_fail(dut, trafficgen, settings, testdata):
         assert True
 
     try:
-        assert clear_interface(trafficgen, trafficgen_pf, trafficgen_ip,
-                               trafficgen_vlan)
+        assert clear_interface(
+            trafficgen, trafficgen_pf, trafficgen_ip, trafficgen_vlan
+        )
         assert False  # Should always short circuit this
     except Exception:
         assert True


### PR DESCRIPTION
The test was sleeping the DUT for longer than the timeout of execute, which would then interfere with cleanup. As a solution lower the sleep to just over timeout (6 seconds on 5 second timeout), and then sleep 1 second before exiting the test