### PR TITLE
Add missing info in testbed_template.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,14 @@ dut:
   pmd_cpus: "30,32,34"      # cpu list used for the testpmd
   interface:
     pf1:
-      name: "ens7f3"        # first PF interface name
-      pci: "0000:ca:00.3"   # first PF PCI address
+      name: "ens7f0"        # first PF interface name
+      pci: "0000:87:00.0"   # first PF PCI address
+    pf2:
+      name: "ens7f1"
+      # For pf2 the pci info is not required
     vf1:
       name: "ens7f3v0"      # first VF interface name
-      pci: "0000:ca:19.0"   # first VF PCI address
+      pci: "0000:87:02.0"   # first VF PCI address
 trafficgen:
   host:                     # TrafficGen ip address
   username: root            # need root access
@@ -79,6 +82,9 @@ trafficgen:
     pf1:
       name: "ens8f0"        # first PF interface name
       mac: "xx:xx:xx..."    # first PF mac address
+    pf2:
+      name: "ens8f1"
+      # For pf2 the MAC address info is not required
 ```
 
 If one chooses to run the test script from the TrafficGen, the trafficgen host will be `127.0.0.1`

--- a/sriov/tests/testbed_template.yaml
+++ b/sriov/tests/testbed_template.yaml
@@ -5,11 +5,14 @@ dut:
   pmd_cpus: "cpu list that will be used to run testpmd on DUT"
   interface:
     pf1:
-      name: "ens7f3"
-      pci: "0000:ca:00.3"
+      name: "ens7f0"
+      pci: "0000:87:00.0"
+    pf2:
+      name: "ens7f1"
+      # For pf2 the pci info is not required
     vf1:
-      name: "ens7f3v0"
-      pci: "0000:ca:19.0"
+      name: "ens7f0v0"
+      pci: "0000:87:02.0"
 trafficgen:
   host: "TrafficGen ip address"
   username: root
@@ -18,3 +21,7 @@ trafficgen:
     pf1:
       name: "ens8f0"
       mac: "40:a6:b7:2b:19:a0"
+    pf2:
+      name: "ens8f1"
+      # For pf2 the MAC address info is not required
+


### PR DESCRIPTION
We missed the information for pf2 in the testbed yaml and the readme.