### PR TITLE
Get PCI and MAC config data from the actual devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,10 @@ dut:
   interface:
     pf1:
       name: "ens7f0"        # first PF interface name
-      pci: "0000:87:00.0"   # first PF PCI address
     pf2:
-      name: "ens7f1"
-      # For pf2 the pci info is not required
+      name: "ens7f1"        # second PF interface name
     vf1:
       name: "ens7f3v0"      # first VF interface name
-      pci: "0000:87:02.0"   # first VF PCI address
 trafficgen:
   host:                     # TrafficGen ip address
   username: root            # need root access
@@ -81,10 +78,8 @@ trafficgen:
   interface:
     pf1:
       name: "ens8f0"        # first PF interface name
-      mac: "xx:xx:xx..."    # first PF mac address
     pf2:
-      name: "ens8f1"
-      # For pf2 the MAC address info is not required
+      name: "ens8f1"        # second PF interface name
 ```
 
 If one chooses to run the test script from the TrafficGen, the trafficgen host will be `127.0.0.1`

--- a/sriov/common/utils.py
+++ b/sriov/common/utils.py
@@ -639,7 +639,7 @@ def vfs_created(
     return False
 
 
-def destroy_vfs(ssh_obj: ShellHandler, pf_interface: str):
+def destroy_vfs(ssh_obj: ShellHandler, pf_interface: str) -> None:
     """Destroy the VFs on pf_interface
 
     Args:

--- a/sriov/common/utils.py
+++ b/sriov/common/utils.py
@@ -639,6 +639,18 @@ def vfs_created(
     return False
 
 
+def destroy_vfs(ssh_obj: ShellHandler, pf_interface: str):
+    """Destroy the VFs on pf_interface
+
+    Args:
+        ssh_obj (ShellHandler): ssh connection obj
+        pf_interface (str): name of the PF
+    """
+    clear_vfs = f"echo 0 > /sys/class/net/{pf_interface}/device/sriov_numvfs"
+    ssh_obj.log_str(clear_vfs)
+    ssh_obj.execute(clear_vfs, 60)
+
+
 def create_vfs(
     ssh_obj: ShellHandler, pf_interface: str, num_vfs: int, timeout: int = 10
 ) -> bool:
@@ -657,9 +669,7 @@ def create_vfs(
     Raises:
         Exception:  failed to create VFs before timeout exceeded
     """
-    clear_vfs = f"echo 0 > /sys/class/net/{pf_interface}/device/sriov_numvfs"
-    ssh_obj.log_str(clear_vfs)
-    ssh_obj.execute(clear_vfs, 60)
+    destroy_vfs(ssh_obj, pf_interface)
     create_vfs = f"echo {num_vfs} > /sys/class/net/{pf_interface}/device/sriov_numvfs"
     ssh_obj.log_str(create_vfs)
     ssh_obj.execute(create_vfs, 60)

--- a/sriov/tests/common/test_utils.py
+++ b/sriov/tests/common/test_utils.py
@@ -1,3 +1,4 @@
+import re
 from sriov.common.utils import (
     get_driver,
     bind_driver,
@@ -27,14 +28,14 @@ from sriov.common.utils import (
 
 
 def test_get_pci_address(dut, settings):
-    pf_pci = settings.config["dut"]["interface"]["pf1"]["pci"]
     pf_name = settings.config["dut"]["interface"]["pf1"]["name"]
-    assert pf_pci == get_pci_address(dut, pf_name)
+    pf_pci = get_pci_address(dut, pf_name)
+    assert re.match(r'^\w{4}:\w{2}:\w{2}', pf_pci)
 
     assert create_vfs(dut, pf_name, 1)
-    vf_pci = settings.config["dut"]["interface"]["vf1"]["pci"]
     vf_name = settings.config["dut"]["interface"]["vf1"]["name"]
-    assert vf_pci == get_pci_address(dut, vf_name)
+    vf_pci = get_pci_address(dut, vf_name)
+    assert re.match(r'^\w{4}:\w{2}:\w{2}', vf_pci)
 
 
 def test_get_driver(dut, settings):
@@ -219,9 +220,9 @@ def test_set_and_reset_mtu(dut, trafficgen, testdata, settings):
 
 
 def test_get_intf_mac(trafficgen, settings):
-    mac = settings.config["trafficgen"]["interface"]["pf1"]["mac"]
     pf_name = settings.config["trafficgen"]["interface"]["pf1"]["name"]
-    assert mac == get_intf_mac(trafficgen, pf_name)
+    mac = get_intf_mac(trafficgen, pf_name)
+    assert re.match(r'^\w{2}:\w{2}:\w{2}:', mac)
 
 
 def test_vf_functions(dut, settings, testdata):

--- a/sriov/tests/testbed_template.yaml
+++ b/sriov/tests/testbed_template.yaml
@@ -6,13 +6,10 @@ dut:
   interface:
     pf1:
       name: "ens7f0"
-      pci: "0000:87:00.0"
     pf2:
       name: "ens7f1"
-      # For pf2 the pci info is not required
     vf1:
       name: "ens7f0v0"
-      pci: "0000:87:02.0"
 trafficgen:
   host: "TrafficGen ip address"
   username: root
@@ -20,8 +17,6 @@ trafficgen:
   interface:
     pf1:
       name: "ens8f0"
-      mac: "40:a6:b7:2b:19:a0"
     pf2:
       name: "ens8f1"
-      # For pf2 the MAC address info is not required
 


### PR DESCRIPTION
Currently we use testbed yaml to statically provide the PCI and MAC information for the PF. In stead of letting the tester manually provide these info (therefore error prone),  a better option is to let the script to get them from the actual devices at the test initialization phase. This is also more user friendly.

The only drawback is the  PCI and MAC util test function can not use the provisioned value as expected value, in stead, a pattern match is used for those function test.