### PR TITLE
Allowing specification of container volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ randomly_terminate_test_length:   # amount of time, in minutes, to run test_SR_I
                                   # example: 10.5
 container_manager:                # the container manager command to use (podman or docker)
                                   # example: podman
-container_volumes:                # the volumes to use with the container command
+container_volumes:                # the volume mapping to use with the container command
                                   # example: "-v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules"
 vlan:                             # vlan tag used by the vlan tests, default is 10
 mtu:                              # MTU size; if unspecified, the script will derive it

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ randomly_terminate_test_length:   # amount of time, in minutes, to run test_SR_I
                                   # example: 10.5
 container_manager:                # the container manager command to use (podman or docker)
                                   # example: podman
+container_volumes:                # the volumes to use with the container command
+                                  # example: "-v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules"
 vlan:                             # vlan tag used by the vlan tests, default is 10
 mtu:                              # MTU size; if unspecified, the script will derive it
 bonding_switch_delay              # Expected bonding switch over/back delay in second, default is 1

--- a/sriov/common/configtestdata.py
+++ b/sriov/common/configtestdata.py
@@ -41,15 +41,15 @@ class ConfigTestData:
         cpus = settings.config["dut"]["pmd_cpus"]
         self.container_cmd = (
             f"{settings.config['container_manager']} run -it --rm --privileged "
-            f"{settings.config['container_volumes']}"
-            f" --cpuset-cpus {cpus} {dpdk_img} dpdk-testpmd -l {cpus} "
+            f"{settings.config['container_volumes']} "
+            f"--cpuset-cpus {cpus} {dpdk_img} dpdk-testpmd -l {cpus} "
             f"-n 4 -a {vf_pci} "
             "-- --nb-cores=2 -i"
         )
         self.container_cmd_echo = (
             f"{settings.config['container_manager']} run -it --rm --privileged "
-            f"{settings.config['container_volumes']}"
-            f" --cpuset-cpus {cpus} {dpdk_img} dpdk-testpmd -l {cpus} "
+            f"{settings.config['container_volumes']} "
+            f"--cpuset-cpus {cpus} {dpdk_img} dpdk-testpmd -l {cpus} "
             f"-n 4 -a {vf_pci} "
             "-- --nb-cores=2 --forward=icmpecho"
         )

--- a/sriov/common/configtestdata.py
+++ b/sriov/common/configtestdata.py
@@ -41,15 +41,15 @@ class ConfigTestData:
         cpus = settings.config["dut"]["pmd_cpus"]
         self.container_cmd = (
             f"{settings.config['container_manager']} run -it --rm --privileged "
-            "-v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules "
-            f"--cpuset-cpus {cpus} {dpdk_img} dpdk-testpmd -l {cpus} "
+            f"{settings.config['container_volumes']}"
+            f" --cpuset-cpus {cpus} {dpdk_img} dpdk-testpmd -l {cpus} "
             f"-n 4 -a {vf_pci} "
             "-- --nb-cores=2 -i"
         )
         self.container_cmd_echo = (
             f"{settings.config['container_manager']} run -it --rm --privileged "
-            "-v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules "
-            f"--cpuset-cpus {cpus} {dpdk_img} dpdk-testpmd -l {cpus} "
+            f"{settings.config['container_volumes']}"
+            f" --cpuset-cpus {cpus} {dpdk_img} dpdk-testpmd -l {cpus} "
             f"-n 4 -a {vf_pci} "
             "-- --nb-cores=2 --forward=icmpecho"
         )

--- a/sriov/tests/SR_IOV_BondVF_DPDK/test_SR_IOV_BondVF_DPDK.py
+++ b/sriov/tests/SR_IOV_BondVF_DPDK/test_SR_IOV_BondVF_DPDK.py
@@ -84,8 +84,8 @@ def dut_setup(dut, settings, testdata, request) -> Bond:
     # are not used.
     container_cmd = (
         f"{settings.config['container_manager']} run -it --rm --privileged "
-        f"{settings.config['container_volumes']}"
-        f" --cpuset-cpus {cpus} {dpdk_img} "
+        f"{settings.config['container_volumes']} "
+        f"--cpuset-cpus {cpus} {dpdk_img} "
         f"dpdk-testpmd -l {cpus} -n 4 "
         f"-a {pci_pf1_vf0} -a {pci_pf1_vf1} -a {pci_pf2_vf0} "
         f"--vdev {vdev_str} "

--- a/sriov/tests/SR_IOV_BondVF_DPDK/test_SR_IOV_BondVF_DPDK.py
+++ b/sriov/tests/SR_IOV_BondVF_DPDK/test_SR_IOV_BondVF_DPDK.py
@@ -84,8 +84,8 @@ def dut_setup(dut, settings, testdata, request) -> Bond:
     # are not used.
     container_cmd = (
         f"{settings.config['container_manager']} run -it --rm --privileged "
-        "-v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules "
-        f"--cpuset-cpus {cpus} {dpdk_img} "
+        f"{settings.config['container_volumes']}"
+        f" --cpuset-cpus {cpus} {dpdk_img} "
         f"dpdk-testpmd -l {cpus} -n 4 "
         f"-a {pci_pf1_vf0} -a {pci_pf1_vf1} -a {pci_pf2_vf0} "
         f"--vdev {vdev_str} "

--- a/sriov/tests/SR_IOV_RandomlyTerminate_DPDK/test_SR_IOV_RandomlyTerminate_DPDK.py
+++ b/sriov/tests/SR_IOV_RandomlyTerminate_DPDK/test_SR_IOV_RandomlyTerminate_DPDK.py
@@ -13,11 +13,13 @@ from sriov.common.utils import (
 )
 
 
-def get_container_cmd(container_manager, name, cpus, dpdk_img, vf_pci):
+def get_container_cmd(
+    container_manager, container_volumes, name, cpus, dpdk_img, vf_pci
+):
     tmux_cmd = (
         f"{container_manager} run -it --name {name} --rm --privileged "
-        "-v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules "
-        f"--cpuset-cpus {cpus} {dpdk_img} dpdk-testpmd -l {cpus} "
+        f"{container_volumes}"
+        f" --cpuset-cpus {cpus} {dpdk_img} dpdk-testpmd -l {cpus} "
         f"-n 4 -a {vf_pci} "
         "-- --nb-cores=1 --forward=txonly -i"
     )
@@ -91,7 +93,12 @@ def test_SR_IOV_RandomlyTerminate_DPDK(dut, settings, testdata, options):
         cpus = get_testpmd_cpus(settings.config["randomly_terminate_control_core"], i)
         name = base_name + str(i)
         tmux_cmd = get_container_cmd(
-            settings.config["container_manager"], name, cpus, dpdk_img, vf_pci
+            settings.config["container_manager"],
+            settings.config["container_volumes"],
+            name,
+            cpus,
+            dpdk_img,
+            vf_pci,
         )
 
         # Start instance of testpmd
@@ -111,7 +118,12 @@ def test_SR_IOV_RandomlyTerminate_DPDK(dut, settings, testdata, options):
                 tmux_session = tmux_list[i][0]
                 vf_pci = tmux_list[i][1]
                 tmux_cmd = get_container_cmd(
-                    settings.config["container_manager"], name, cpus, dpdk_img, vf_pci
+                    settings.config["container_manager"],
+                    settings.config["container_volumes"],
+                    name,
+                    cpus,
+                    dpdk_img,
+                    vf_pci,
                 )
 
                 # Kill the container

--- a/sriov/tests/SR_IOV_RandomlyTerminate_DPDK/test_SR_IOV_RandomlyTerminate_DPDK.py
+++ b/sriov/tests/SR_IOV_RandomlyTerminate_DPDK/test_SR_IOV_RandomlyTerminate_DPDK.py
@@ -18,8 +18,8 @@ def get_container_cmd(
 ):
     tmux_cmd = (
         f"{container_manager} run -it --name {name} --rm --privileged "
-        f"{container_volumes}"
-        f" --cpuset-cpus {cpus} {dpdk_img} dpdk-testpmd -l {cpus} "
+        f"{container_volumes} "
+        f"--cpuset-cpus {cpus} {dpdk_img} dpdk-testpmd -l {cpus} "
         f"-n 4 -a {vf_pci} "
         "-- --nb-cores=1 --forward=txonly -i"
     )

--- a/sriov/tests/common/test_exec.py
+++ b/sriov/tests/common/test_exec.py
@@ -66,9 +66,10 @@ def test_start_and_stop_testpmd(dut, settings):
         assert code == 0, step
     testpmd_container_cmd = (
         f"{settings.config['container_manager']} run -it --rm --privileged "
-        "-v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules "
-        "--cpuset-cpus 30,32,34 docker.io/patrickkutch/dpdk:v21.11 "
-        "dpdk-testpmd -l 30,32,34 -n 4 -a " + vf_pci + " -- --nb-cores=2 -i"
+        f"{settings.config['container_volumes']}"
+        f" --cpuset-cpus {settings.config['dut']['pmd_cpus']} "
+        f"{settings.config['dpdk_img']} dpdk-testpmd -l "
+        f"{settings.config['dut']['pmd_cpus']} -n 4 -a {vf_pci} -- --nb-cores=2 -i"
     )
     code, out, err = dut.start_testpmd(testpmd_container_cmd)
     assert code == 0

--- a/sriov/tests/common/test_exec.py
+++ b/sriov/tests/common/test_exec.py
@@ -66,8 +66,8 @@ def test_start_and_stop_testpmd(dut, settings):
         assert code == 0, step
     testpmd_container_cmd = (
         f"{settings.config['container_manager']} run -it --rm --privileged "
-        f"{settings.config['container_volumes']}"
-        f" --cpuset-cpus {settings.config['dut']['pmd_cpus']} "
+        f"{settings.config['container_volumes']} "
+        f"--cpuset-cpus {settings.config['dut']['pmd_cpus']} "
         f"{settings.config['dpdk_img']} dpdk-testpmd -l "
         f"{settings.config['dut']['pmd_cpus']} -n 4 -a {vf_pci} -- --nb-cores=2 -i"
     )

--- a/sriov/tests/config_template.yaml
+++ b/sriov/tests/config_template.yaml
@@ -7,6 +7,7 @@ randomly_terminate_max_vfs: 8
 randomly_terminate_test_chance: 0.5
 randomly_terminate_test_length: 10.5
 container_manager: podman
+container_volumes: "-v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules"
 vlan: 10
 mtu: 1500
 bonding_switch_delay: 5


### PR DESCRIPTION
Allow container_volumes field in config, updating tests and common reliant on container commands, update unit tests for specified fields of containers.
Addressing https://github.com/redhat-partner-solutions/rhel-sriov-test/issues/93
Report: https://gist.github.com/dkosteck/edbc40f7321aa9f8d6b5d400bcc18db2