### PR TITLE
Traffic isn't sent to client when  spoof checking is enabled on VF during testcase SR_IOV_BondVF[dut_setup0] and  SR_IOV_BondVF[dut_setup2] (Issue #153) fix

### DIFF
--- a/sriov/common/exec.py
+++ b/sriov/common/exec.py
@@ -23,9 +23,9 @@ class ShellHandler:
         self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         try:
             if psw is None:
-                self.ssh.connect(host, username=user, port=22)
+                self.ssh.connect(host, username=user, port=22, timeout=10)
             else:
-                self.ssh.connect(host, username=user, password=psw, port=22)
+                self.ssh.connect(host, username=user, password=psw, port=22, timeout=10)
 
         except paramiko.AuthenticationException:
             print("ERROR: invalid credentials provided for {}".format(host))


### PR DESCRIPTION
This code adds the disable spoofcheck into the test_SR_IOV_BONDVF.py by setting spoofcheck off to continue traffic on vfs.