### PR TITLE
adding abiltiy to bind driver with dpdk-devbind.py that resides in th…

### DIFF
--- a/sriov/common/exec.py
+++ b/sriov/common/exec.py
@@ -295,8 +295,10 @@ class ShellHandler:
         print(print_out)
 
     def executeWithSearch(self, cmd: str, assertOnStr: str, timeout: int = 5) \
-            -> Tuple[int,list, str]:  # noqa: C901
-        """Execute a command in the SSH session, designed for the command to be a podman/docker execution of a command in a container
+            -> Tuple[int, list, list]:  # noqa: C901
+        """  Execute a command in the SSH session, designed for 
+             the command to be a podman/docker execution of a 
+             command in a container
 
         Args:
             self:          self
@@ -313,7 +315,7 @@ class ShellHandler:
         finish = "end of stdOUT buffer."
         echo_cmd = ";echo {} ".format(finish)
 
-        #run the command and the echo in one shot
+        # run the command and the echo in one shot
         self.stdin.write(cmd + echo_cmd + "\n")
         self.stdin.flush()
 
@@ -325,14 +327,14 @@ class ShellHandler:
 
         try:
             for line in self.stdout:
-                if  ShellHandler.debug_cmd_execute:
+                if ShellHandler.debug_cmd_execute:
                     print(f"Got line: {repr(line)}")
                 if str(line).endswith(cmd + "\r\n") or str(line).endswith(cmd + "\n"):
-                    #up for now filled with shell junk from stdin
+                    # up for now filled with shell junk from stdin
                     if ShellHandler.debug_cmd_execute:
                         print("reset shout")
-                    #shout = []
-                    pass
+                    shout = []
+
                 if echo_cmd in str(line):
                     if ShellHandler.debug_cmd_execute:
                         print("skip line")
@@ -379,4 +381,4 @@ class ShellHandler:
         if ShellHandler.debug_cmd_execute:
             print(f"returning shout: {shout}")
             print(f"returning sherr: {sherr}")
-        return exit_status,shout, sherr
+        return exit_status, shout, sherr

--- a/sriov/common/exec.py
+++ b/sriov/common/exec.py
@@ -303,6 +303,8 @@ class ShellHandler:
         Args:
             self:          self
             cmd (str):     the command to execute over SSH
+            assertOnStr(str): throws an assert if the output of the command
+                              contains this string
             timeout (int): timeout for command to run (default 5)
 
         Returns:
@@ -358,7 +360,7 @@ class ShellHandler:
                 # check if present, if it is then break
                 if assertOnStr and assertOnStr in line:
                     if ShellHandler.debug_cmd_execute:
-                        print(f"found string to asset on [{assertOnStr}] in: {line}")
+                        print(f"found string to assert on [{assertOnStr}] in: {line}")
 
                     sherr = line
                     exit_status = -1

--- a/sriov/common/exec.py
+++ b/sriov/common/exec.py
@@ -310,7 +310,8 @@ class ShellHandler:
         Returns:
             exit_status (int): the exit status (0 on success, non-zero otherwise)
             shout (list):      list of stdout lines
-            sherr :            the line where (if it is found) the assertOnStr string was found
+            sherr :            the line where (if it is found) the
+                               assertOnStr string was found
         """
         cmd = cmd.strip("\n")
 

--- a/sriov/common/exec.py
+++ b/sriov/common/exec.py
@@ -296,8 +296,8 @@ class ShellHandler:
 
     def executeWithSearch(self, cmd: str, assertOnStr: str, timeout: int = 5) \
             -> Tuple[int, list, list]:  # noqa: C901
-        """  Execute a command in the SSH session, designed for 
-             the command to be a podman/docker execution of a 
+        """  Execute a command in the SSH session, designed for
+             the command to be a podman/docker execution of a
              command in a container
 
         Args:

--- a/sriov/common/utils.py
+++ b/sriov/common/utils.py
@@ -56,8 +56,10 @@ def bind_driver(ssh_obj: ShellHandler, pci: str, driver: str, timeout: int = 5) 
     return True
 
 
-def bind_driver_with_dpdk(settings: object, ssh_obj: ShellHandler, pci: str, driver: str, timeout: int = 5) -> bool:
-    """ Bind the PCI address to the driver using dpdk-devbind.py in the dpdk container
+def bind_driver_with_dpdk(settings: object, ssh_obj: ShellHandler, pci: str,
+                          driver: str, timeout: int = 5) -> bool:
+    """ Bind the PCI address to the driver using dpdk-devbind.py
+        in the dpdk container
 
     Args:
         ssh_obj:       ssh_obj to the remote host

--- a/sriov/common/utils.py
+++ b/sriov/common/utils.py
@@ -55,8 +55,8 @@ def bind_driver(ssh_obj: ShellHandler, pci: str, driver: str, timeout: int = 5) 
             raise Exception(err)
     return True
 
-def bind_driver_with_dpdk(settings, ssh_obj: ShellHandler, pci: str, driver: str, timeout: int = 5) -> bool:
-    """Bind the PCI address to the driver using dpdk-devbind.py in the dpdk container
+def bind_driver_with_dpdk(settings: object, ssh_obj: ShellHandler, pci: str, driver: str, timeout: int = 5) -> bool:
+    """ Bind the PCI address to the driver using dpdk-devbind.py in the dpdk container
 
     Args:
         ssh_obj:       ssh_obj to the remote host
@@ -70,26 +70,26 @@ def bind_driver_with_dpdk(settings, ssh_obj: ShellHandler, pci: str, driver: str
     Raises:
         Exception: command failure
     """
-    
+
     # use dpdk-devbind.py within the dpdk container to do the binding
-    dpdk_devbind_cmd=(
+    dpdk_devbind_cmd = (
             f"{settings.config['container_manager']} run -it --rm --privileged "
             f"{settings.config['container_volumes']} "
             f"{settings.config['dpdk_img']} dpdk-devbind.py -b {driver} {pci}\n"
         )
-    
+
     steps = [
-        ("modprobe {}".format(driver),None),
-        (dpdk_devbind_cmd,"Error")
+        ("modprobe {}".format(driver), None),
+        (dpdk_devbind_cmd, "Error")
     ]
 
-    for step,errorOnStr in steps:
+    for step, errorOnStr in steps:
         ssh_obj.log_str(step)
         # use executeWithSearch because you cannot get the errorcode
         # from the container, so we search stdout for a desired error string
-        code,out, err = ssh_obj.executeWithSearch(step, errorOnStr,timeout)
+        code, out, err = ssh_obj.executeWithSearch(step, errorOnStr, timeout)
         if code != 0:
-             raise Exception(err)
+            raise Exception(err)
     return True
 
 

--- a/sriov/common/utils.py
+++ b/sriov/common/utils.py
@@ -55,6 +55,7 @@ def bind_driver(ssh_obj: ShellHandler, pci: str, driver: str, timeout: int = 5) 
             raise Exception(err)
     return True
 
+
 def bind_driver_with_dpdk(settings: object, ssh_obj: ShellHandler, pci: str, driver: str, timeout: int = 5) -> bool:
     """ Bind the PCI address to the driver using dpdk-devbind.py in the dpdk container
 

--- a/sriov/common/utils.py
+++ b/sriov/common/utils.py
@@ -76,8 +76,7 @@ def bind_driver_with_dpdk(settings: object, ssh_obj: ShellHandler, pci: str, dri
     dpdk_devbind_cmd = (
             f"{settings.config['container_manager']} run -it --rm --privileged "
             f"{settings.config['container_volumes']} "
-            f"{settings.config['dpdk_img']} dpdk-devbind.py -b {driver} {pci}\n"
-        )
+            f"{settings.config['dpdk_img']} dpdk-devbind.py -b {driver} {pci}\n")
 
     steps = [
         ("modprobe {}".format(driver), None),

--- a/sriov/common/utils.py
+++ b/sriov/common/utils.py
@@ -74,9 +74,9 @@ def bind_driver_with_dpdk(settings: object, ssh_obj: ShellHandler, pci: str, dri
 
     # use dpdk-devbind.py within the dpdk container to do the binding
     dpdk_devbind_cmd = (
-            f"{settings.config['container_manager']} run -it --rm --privileged "
-            f"{settings.config['container_volumes']} "
-            f"{settings.config['dpdk_img']} dpdk-devbind.py -b {driver} {pci}\n")
+        f"{settings.config['container_manager']} run -it --rm --privileged "
+        f"{settings.config['container_volumes']} "
+        f"{settings.config['dpdk_img']} dpdk-devbind.py -b {driver} {pci}\n")
 
     steps = [
         ("modprobe {}".format(driver), None),

--- a/sriov/common/utils.py
+++ b/sriov/common/utils.py
@@ -55,6 +55,43 @@ def bind_driver(ssh_obj: ShellHandler, pci: str, driver: str, timeout: int = 5) 
             raise Exception(err)
     return True
 
+def bind_driver_with_dpdk(settings, ssh_obj: ShellHandler, pci: str, driver: str, timeout: int = 5) -> bool:
+    """Bind the PCI address to the driver using dpdk-devbind.py in the dpdk container
+
+    Args:
+        ssh_obj:       ssh_obj to the remote host
+        pci (str):     PCI address, example "0000:17:00.0"
+        driver (str):  driver name, example "vfio-pci"
+        timeout (int): seconds of timeout for execute, default of 5
+
+    Returns:
+        True: on success of binding
+
+    Raises:
+        Exception: command failure
+    """
+    
+    # use dpdk-devbind.py within the dpdk container to do the binding
+    dpdk_devbind_cmd=(
+            f"{settings.config['container_manager']} run -it --rm --privileged "
+            f"{settings.config['container_volumes']} "
+            f"{settings.config['dpdk_img']} dpdk-devbind.py -b {driver} {pci}\n"
+        )
+    
+    steps = [
+        ("modprobe {}".format(driver),None),
+        (dpdk_devbind_cmd,"Error")
+    ]
+
+    for step,errorOnStr in steps:
+        ssh_obj.log_str(step)
+        # use executeWithSearch because you cannot get the errorcode
+        # from the container, so we search stdout for a desired error string
+        code,out, err = ssh_obj.executeWithSearch(step, errorOnStr,timeout)
+        if code != 0:
+             raise Exception(err)
+    return True
+
 
 def get_driver(ssh_obj: ShellHandler, intf: str, timeout: int = 5) -> str:
     """Get the interface driver

--- a/sriov/tests/common/test_utils.py
+++ b/sriov/tests/common/test_utils.py
@@ -24,6 +24,7 @@ from sriov.common.utils import (
     verify_vf_address,
     vfs_created,
     no_zero_macs_pf,
+    bind_driver_with_dpdk
 )
 
 
@@ -47,7 +48,8 @@ def test_bind_driver(dut, settings):
     pf_name = settings.config["dut"]["interface"]["pf1"]["name"]
     assert create_vfs(dut, pf_name, 1)
     vf_pci = settings.config["dut"]["interface"]["vf1"]["pci"]
-    assert bind_driver(dut, vf_pci, "vfio-pci")
+    assert bind_driver_with_dpdk(settings, dut, vf_pci, "vfio-pci")
+
 
 
 def test_config_and_clear_interface(dut, trafficgen, settings, testdata):

--- a/sriov/tests/common/test_utils.py
+++ b/sriov/tests/common/test_utils.py
@@ -48,6 +48,13 @@ def test_bind_driver(dut, settings):
     pf_name = settings.config["dut"]["interface"]["pf1"]["name"]
     assert create_vfs(dut, pf_name, 1)
     vf_pci = settings.config["dut"]["interface"]["vf1"]["pci"]
+    assert bind_driver(dut, vf_pci, "vfio-pci")
+
+
+def test_bind_driver_using_dpdk(dut, settings):
+    pf_name = settings.config["dut"]["interface"]["pf1"]["name"]
+    assert create_vfs(dut, pf_name, 1)
+    vf_pci = settings.config["dut"]["interface"]["vf1"]["pci"]
     assert bind_driver_with_dpdk(settings, dut, vf_pci, "vfio-pci")
 
 

--- a/sriov/tests/common/test_utils.py
+++ b/sriov/tests/common/test_utils.py
@@ -2,6 +2,7 @@ import re
 from sriov.common.utils import (
     get_driver,
     bind_driver,
+    bind_driver_with_dpdk,
     start_tmux,
     stop_tmux,
     execute_and_assert,
@@ -24,7 +25,6 @@ from sriov.common.utils import (
     verify_vf_address,
     vfs_created,
     no_zero_macs_pf,
-    bind_driver_with_dpdk
 )
 
 
@@ -49,7 +49,6 @@ def test_bind_driver(dut, settings):
     assert create_vfs(dut, pf_name, 1)
     vf_pci = settings.config["dut"]["interface"]["vf1"]["pci"]
     assert bind_driver_with_dpdk(settings, dut, vf_pci, "vfio-pci")
-
 
 
 def test_config_and_clear_interface(dut, trafficgen, settings, testdata):


### PR DESCRIPTION
I created a new way of binding the driver.  There is now a bind_driver_with_dpdk() that uses the dpdk-devbind.py tool that is designed for doing this.

Also created a new execute function called executeWithSearch() that can search stdout for a specified error string - because you cannot get an errorcode from an application run in a container

I've not changed any of the other code (except test_utils::test_bind_driver) to make user of the new bind_driver_with_dpdk().  I wanted to get you guys to look at what I did before we change bind_driver() calls to bind_driver_with_dpdk()