### PR TITLE
Increase e2e artifacts retention and document it

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -87,7 +87,7 @@ jobs:
         with:
           name: html-report
           path: sriov/tests/report.html
-          retention-days: 3
+          retention-days: 30
       - name: Display Status
         run: echo "This job's status is ${{ job.status }}."
   remove-label:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,3 +91,5 @@ All SR-IOV and common tests should be validated to work and, in cases where chan
 The optional "real" testing can be run by applying the "e2e-test" label to the Pull Request. This will start an action which queues either an end-to-end test (where common code is affected) or runs the specific test modified (when no common code is affected). Because these tests take both time and resources, they should only be started after the PR is ready to merge as a final check of functionality, and this label should only be utilized by repository maintainers. After the test run, the Action will remove the "e2e-test" label.
 
 "e2e-test" label triggers end-to-end test execution using 810-series NIC ports. Alternatively, "e2e-test-710" label can be used for end-to-end test execution on 710-series NICs.
+
+e2e pytest html test result is preserved by upload-artifact action. You can find an archived results file at the bottom of the workflow summary page in the [dedicated section for artifacts](https://github.com/actions/upload-artifact#where-does-the-upload-go). The results archive will be preserved in the repositogy workspace for 30 days.


### PR DESCRIPTION
A couple of small usability improvements for CI e2e test result storage: increase retention from 3 to 30 days and update CONTRIBUTING.md to reflect this change. 