### PR TITLE
Renaming Performance to Sanity Performance

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -67,10 +67,10 @@ jobs:
           cd sriov/tests
           cp /config/*.yaml ./
           if [[ "${mode}" == "full" ]]; then
-            pytest -v --html=report.html --self-contained-html SR_IOV_* common --ignore-glob="*test_SR_IOV_Performance.py"
+            pytest -v --html=report.html --self-contained-html SR_IOV_* common --ignore-glob="*test_SR_IOV_Sanity_Performance.py"
             echo "generated=true" >> $GITHUB_ENV
           elif [[ ${#tests[@]} -ne 0 ]]; then
-            test_string="pytest -v --html=report.html --self-contained-html --ignore-glob='*test_SR_IOV_Performance.py'"
+            test_string="pytest -v --html=report.html --self-contained-html --ignore-glob='*test_SR_IOV_Sanity_Performance.py'"
             for testname in $(echo "${tests[@]}" | tr ' ' '\n' | sort -u); do
               test_string="${test_string} ${testname}"
               echo "Testing ${testname}"

--- a/README.md
+++ b/README.md
@@ -109,14 +109,14 @@ container_volumes:                # the volume mapping to use with the container
 vlan:                             # vlan tag used by the vlan tests, default is 10
 mtu:                              # MTU size; if unspecified, the script will derive it
 bonding_switch_delay:             # Expected bonding switch over/back delay in second, default is 1
-# Below required for SR_IOV_Performance
+# Below required for SR_IOV_Sanity_Performance
 testpmd_img:                      # testpmd container image
 testpmd_port:                     # testpmd REST port
 trafficgen_img:                   # trafficgen container image
 trafficgen_port:                  # trafficgen REST port
 trafficgen_timeout:               # trafficgen command timeout (in minutes)
 trafficgen_rx_bps_limit:          # trafficgen baseline comparison (bps)
-log_performance:                  # boolean, use false to omit performance test details in logs/result files (only pass or fail)
+log_performance:                  # boolean, use false to omit sanity performance test details in logs/result files (only pass or fail)
 ```
 
 A current version of Python is recommended to run the tests. As of writing the minimum version to avoid warnings would be 3.7. However, the tests have been successfully run up to version 3.11, the latest active release as of writing. The same is true of pip, which should be a current version (23.0 as of writing, but this should be upgraded in the following steps).

--- a/sriov/tests/SR_IOV_Sanity_Performance/README.md
+++ b/sriov/tests/SR_IOV_Sanity_Performance/README.md
@@ -1,6 +1,6 @@
-# Test Case Name: SR-IOV.Performance
+# Test Case Name: SR-IOV.Sanity.Performance
 
-### Objective(s): A RFC2544 performance test to evaluate a system's (relative) performance when running DPDK workloads. This relies on a trafficgen client and containers built from [netgauge](https://github.com/redhat-eets/netgauge)
+### Objective(s): A RFC2544 sanity test to evaluate a system's (relative) performance when running DPDK workloads. This relies on a trafficgen client and containers built from [netgauge](https://github.com/redhat-eets/netgauge)
 
 ### Test procedure
 

--- a/sriov/tests/SR_IOV_Sanity_Performance/test_SR_IOV_Sanity_Performance.py
+++ b/sriov/tests/SR_IOV_Sanity_Performance/test_SR_IOV_Sanity_Performance.py
@@ -13,7 +13,7 @@ import json
 
 # Use pytest --iteration to adjust the execution_number parameter for desired amount
 # of repeated tests
-def test_SRIOVPerformance(dut, trafficgen, settings, testdata):
+def test_SRIOV_Sanity_Performance(dut, trafficgen, settings, testdata):
     """Test and ensure that VFs provision with MTU functions as intended
 
     Args:


### PR DESCRIPTION
I made the decision to retain "performance" but make it more clear with "sanity performance". Feel free to give opinions on this renaming, or if just "sanity" is clear enough. I felt that just "sanity" is too broad, and does not really convey what the test does.