### PR TITLE
Initial working elastic logging for sanity performance tests:

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,11 @@ The test execution will stop immediately without cleaning up, and one may access
 
 After the debug is complete, one has to manually clean up the setup.
 
-## Uncommon options
+## Uncommon Options
 
 The following test options are uncommon and meant to use under rare situations:
 + `--debug-execute`: debug command execution over the ssh session
 
+## Storing Test Results (Experimental)
+
+A natural extension of this testing framework involves storing results of tests for historical purposes, as well as to query the data afterwords. To this end we have implemented a (currently experimental/in development) integration allowing the results of `SR_IOV_Sanity_Performance` to be pushed to an Elasticsearch instance. To see config fields required for using Elastic, see the `Usage` section above. As noted, this is an initial implementation and further development is needed to flesh out features.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ trafficgen_port:                  # trafficgen REST port
 trafficgen_timeout:               # trafficgen command timeout (in minutes)
 trafficgen_rx_bps_limit:          # trafficgen baseline comparison (bps)
 log_performance:                  # boolean, use false to omit sanity performance test details in logs/result files (only pass or fail)
-log_performance_elastic:          # boolean, use true to upload to bps to elastic node
+log_performance_elastic:          # boolean, use true to upload the sanity performance bps to elastic node
+# Below configures the SR_IOV_Sanity_Performance Elastic parameters, if log_performance_elastic is set
 elastic_host:                     # IP address or hostname of elastic
 elastic_port:                     # Port of elastic
 elastic_username:                 # Elastic username
@@ -186,7 +187,7 @@ The common code has its own test cases. The majority of the common code test cas
 
 A small portion of common code test cases are done using mock. These mock unit test cases are under the `sriov/common` folder, along with the common code itself. The purpose of the mock unit tests is to cover scenarios that are difficult to cover via the e2e tests. These tests must be run from the root of the repo, unless one sets the `PYTHONPATH` environment variable to include the root, in which case the mock tests may be run from another directory.
 
-## Debug Failed Test Case
+## Debug Failed Test Cases
 
 When a test case is failing, one may want to immediately stop the test run and keep the failed setup for manual debugging. This can not be achieved with the pytest `-x` option, as `-x` still allow the cleanup to happen. Instead, this can be done by using the `--skipclean` option.
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ trafficgen_port:                  # trafficgen REST port
 trafficgen_timeout:               # trafficgen command timeout (in minutes)
 trafficgen_rx_bps_limit:          # trafficgen baseline comparison (bps)
 log_performance:                  # boolean, use false to omit sanity performance test details in logs/result files (only pass or fail)
+log_performance_elastic:          # boolean, use true to upload to bps to elastic node
+elastic_host:                     # IP address or hostname of elastic
+elastic_port:                     # Port of elastic
+elastic_username:                 # Elastic username
+elastic_password:                 # Elastic password
 ```
 
 A current version of Python is recommended to run the tests. As of writing the minimum version to avoid warnings would be 3.7. However, the tests have been successfully run up to version 3.11, the latest active release as of writing. The same is true of pip, which should be a current version (23.0 as of writing, but this should be upgraded in the following steps).

--- a/sriov/common/configtestdata.py
+++ b/sriov/common/configtestdata.py
@@ -1,11 +1,7 @@
 from sriov.common.config import Config
-import json
 
 
 class ConfigTestData:
-    def to_json(self):
-        return json.dumps(self)
-    
     def __init__(self, settings: Config) -> None:
         """Init the testdata object
 
@@ -63,4 +59,3 @@ class ConfigTestData:
         # track testpmd and trafficgen container IDs from SR_IOV_Performance for cleanup
         self.testpmd_id = ""
         self.trafficgen_id = ""
-

--- a/sriov/common/configtestdata.py
+++ b/sriov/common/configtestdata.py
@@ -59,3 +59,4 @@ class ConfigTestData:
         # track testpmd and trafficgen container IDs from SR_IOV_Performance for cleanup
         self.testpmd_id = ""
         self.trafficgen_id = ""
+

--- a/sriov/common/configtestdata.py
+++ b/sriov/common/configtestdata.py
@@ -1,7 +1,11 @@
 from sriov.common.config import Config
+import json
 
 
 class ConfigTestData:
+    def to_json(self):
+        return json.dumps(self)
+    
     def __init__(self, settings: Config) -> None:
         """Init the testdata object
 

--- a/sriov/requirements.txt
+++ b/sriov/requirements.txt
@@ -4,3 +4,4 @@ PyYAML==6.0
 pytest-html
 docutils
 gitpython
+elasticsearch

--- a/sriov/tests/SR_IOV_MTU/test_SR_IOV_MTU.py
+++ b/sriov/tests/SR_IOV_MTU/test_SR_IOV_MTU.py
@@ -9,6 +9,7 @@ from sriov.common.utils import (
     get_vf_mac,
     switch_detected,
 )
+import time
 
 
 def test_SR_IOV_MTU(dut, trafficgen, settings, testdata):
@@ -58,6 +59,7 @@ def test_SR_IOV_MTU(dut, trafficgen, settings, testdata):
     else:
         mtu = min(dut_mtu, trafficgen_mtu)
 
+    time.sleep(5)
     assert set_mtu(trafficgen, trafficgen_pf, dut, pf, 0, mtu, testdata)
 
     steps = [f"ip link set {pf}v0 up", f"ip add add {dut_ip}/24 dev {pf}v0"]

--- a/sriov/tests/SR_IOV_Sanity_Performance/test_SR_IOV_Sanity_Performance.py
+++ b/sriov/tests/SR_IOV_Sanity_Performance/test_SR_IOV_Sanity_Performance.py
@@ -15,7 +15,7 @@ import json
 
 # Use pytest --iteration to adjust the execution_number parameter for desired amount
 # of repeated tests
-def test_SRIOV_Sanity_Performance(dut, trafficgen, settings, testdata):
+def test_SRIOV_Sanity_Performance(dut, trafficgen, settings, testdata): # noqa: C901
     """Test and ensure that VFs provision with MTU functions as intended
 
     Args:

--- a/sriov/tests/SR_IOV_Sanity_Performance/test_SR_IOV_Sanity_Performance.py
+++ b/sriov/tests/SR_IOV_Sanity_Performance/test_SR_IOV_Sanity_Performance.py
@@ -206,4 +206,3 @@ def log_elastic(results):
     elastic.elastic_doc["timestamp"] = datetime.now()
 
     print(elastic.elastic_index)
-    

--- a/sriov/tests/SR_IOV_Sanity_Performance/test_SR_IOV_Sanity_Performance.py
+++ b/sriov/tests/SR_IOV_Sanity_Performance/test_SR_IOV_Sanity_Performance.py
@@ -24,7 +24,7 @@ def test_SRIOV_Sanity_Performance(dut, trafficgen, settings, testdata):  # noqa:
         testdata:         testdata obj
         execution_number: execution_number parameter
     """
-    '''dut_pfs = list(testdata.pfs.keys())
+    dut_pfs = list(testdata.pfs.keys())
 
     assert set_pipefail(dut)
 
@@ -189,21 +189,20 @@ def test_SRIOV_Sanity_Performance(dut, trafficgen, settings, testdata):  # noqa:
         client_cmd,
         0,
         cmd_timeout=60 * settings.config["trafficgen_timeout"],
-    )'''
-    results = "" #json.loads(outs[0][0])
+    )
+    results = json.loads(outs[0][0])
     if settings.config["log_performance"]:
         print(json.dumps(results))
     if settings.config["log_performance_elastic"]:
-        log_elastic()
+        log_elastic(results)
 
     # Compare trafficgen results to config
-    #assert results["0"]["rx_l1_bps"] >= settings.config["trafficgen_rx_bps_limit"]
+    assert results["0"]["rx_l1_bps"] >= settings.config["trafficgen_rx_bps_limit"]
 
 
-def log_elastic():
+def log_elastic(results):
     elastic.elastic_index = "test-perf-index"
-    elastic.elastic_doc = {}
-    #elastic.elastic_doc["rx_l1_bps"] = results["0"]["rx_l1_bps"]
+    elastic.elastic_doc["rx_l1_bps"] = results["0"]["rx_l1_bps"]
     elastic.elastic_doc["timestamp"] = datetime.now()
 
     print(elastic.elastic_index)

--- a/sriov/tests/SR_IOV_Sanity_Performance/test_SR_IOV_Sanity_Performance.py
+++ b/sriov/tests/SR_IOV_Sanity_Performance/test_SR_IOV_Sanity_Performance.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from elasticsearch import Elasticsearch
+from sriov.tests.conftest import elastic
 from sriov.common.utils import (
     execute_and_assert,
     execute_until_timeout,
@@ -24,7 +24,7 @@ def test_SRIOV_Sanity_Performance(dut, trafficgen, settings, testdata):  # noqa:
         testdata:         testdata obj
         execution_number: execution_number parameter
     """
-    dut_pfs = list(testdata.pfs.keys())
+    '''dut_pfs = list(testdata.pfs.keys())
 
     assert set_pipefail(dut)
 
@@ -189,32 +189,22 @@ def test_SRIOV_Sanity_Performance(dut, trafficgen, settings, testdata):  # noqa:
         client_cmd,
         0,
         cmd_timeout=60 * settings.config["trafficgen_timeout"],
-    )
-    results = json.loads(outs[0][0])
+    )'''
+    results = "" #json.loads(outs[0][0])
     if settings.config["log_performance"]:
         print(json.dumps(results))
     if settings.config["log_performance_elastic"]:
         log_elastic(settings, results)
 
     # Compare trafficgen results to config
-    assert results["0"]["rx_l1_bps"] >= settings.config["trafficgen_rx_bps_limit"]
+    #assert results["0"]["rx_l1_bps"] >= settings.config["trafficgen_rx_bps_limit"]
 
 
-def log_elastic(settings, results):
-    es = Elasticsearch(
-        f'https://{settings.config["elastic_host"]}:{settings.config["elastic_port"]}',
-        verify_certs=False,
-        # ca_certs=settings.config["elastic_ca_cert_path"],
-        basic_auth=(
-            settings.config["elastic_username"],
-            settings.config["elastic_password"],
-        ),
-    )
-    es.info()
+def log_elastic(testdata, results):
+    elastic.elastic_index = "test-perf-index"
+    elastic.elastic_doc = {}
+    #testdata.elastic_doc["rx_l1_bps"] = results["0"]["rx_l1_bps"]
+    elastic.elastic_doc["timestamp"] = datetime.now()
 
-    doc = {
-        "rx_l1_bps": results["0"]["rx_l1_bps"],
-        "timestamp": datetime.now(),
-    }
-    resp = es.index(index="test-perf-index", document=doc)
-    print(resp["result"])
+    print(elastic.elastic_index)
+    

--- a/sriov/tests/SR_IOV_Sanity_Performance/test_SR_IOV_Sanity_Performance.py
+++ b/sriov/tests/SR_IOV_Sanity_Performance/test_SR_IOV_Sanity_Performance.py
@@ -194,16 +194,16 @@ def test_SRIOV_Sanity_Performance(dut, trafficgen, settings, testdata):  # noqa:
     if settings.config["log_performance"]:
         print(json.dumps(results))
     if settings.config["log_performance_elastic"]:
-        log_elastic(settings, results)
+        log_elastic()
 
     # Compare trafficgen results to config
     #assert results["0"]["rx_l1_bps"] >= settings.config["trafficgen_rx_bps_limit"]
 
 
-def log_elastic(testdata, results):
+def log_elastic():
     elastic.elastic_index = "test-perf-index"
     elastic.elastic_doc = {}
-    #testdata.elastic_doc["rx_l1_bps"] = results["0"]["rx_l1_bps"]
+    #elastic.elastic_doc["rx_l1_bps"] = results["0"]["rx_l1_bps"]
     elastic.elastic_doc["timestamp"] = datetime.now()
 
     print(elastic.elastic_index)

--- a/sriov/tests/SR_IOV_Sanity_Performance/test_SR_IOV_Sanity_Performance.py
+++ b/sriov/tests/SR_IOV_Sanity_Performance/test_SR_IOV_Sanity_Performance.py
@@ -15,7 +15,7 @@ import json
 
 # Use pytest --iteration to adjust the execution_number parameter for desired amount
 # of repeated tests
-def test_SRIOV_Sanity_Performance(dut, trafficgen, settings, testdata): # noqa: C901
+def test_SRIOV_Sanity_Performance(dut, trafficgen, settings, testdata):  # noqa: C901
     """Test and ensure that VFs provision with MTU functions as intended
 
     Args:

--- a/sriov/tests/config_template.yaml
+++ b/sriov/tests/config_template.yaml
@@ -18,3 +18,9 @@ trafficgen_port: 8080
 trafficgen_timeout: 12
 trafficgen_rx_bps_limit: 9990000000
 log_performance: false
+log_performance_elastic: true
+elastic_host: 192.168.1.1
+elastic_port: 9200
+#elastic_ca_cert_path: "./http_ca.crt"
+elastic_username: "elastic"
+elastic_password: "PASSWORD"

--- a/sriov/tests/conftest.py
+++ b/sriov/tests/conftest.py
@@ -347,7 +347,10 @@ def pytest_generate_tests(metafunc) -> None:
 def elastic_push(settings, testdata):
     if settings.config["log_performance_elastic"]:
         es = Elasticsearch(
-            f'https://{settings.config["elastic_host"]}:{settings.config["elastic_port"]}',
+            (
+                f'https://{settings.config["elastic_host"]}:'
+                + f'{settings.config["elastic_port"]}'
+            ),
             verify_certs=False,
             # ca_certs=settings.config["elastic_ca_cert_path"],
             basic_auth=(

--- a/sriov/tests/conftest.py
+++ b/sriov/tests/conftest.py
@@ -21,7 +21,7 @@ from sriov.common.utils import (
 )
 
 class elastic:
-    # track elastic results from SR_IOV_Sanity_Performance
+    # track elastic results (currently used in SR_IOV_Sanity_Performance)
     elastic_index = None
     elastic_doc = {}
 
@@ -181,7 +181,8 @@ def _cleanup(
     reset_command(dut, testdata)
 
     if settings.config["log_performance_elastic"]:
-        es = Elasticsearch(
+        elastic_push(settings, testdata)
+        '''es = Elasticsearch(
             f'https://{settings.config["elastic_host"]}:{settings.config["elastic_port"]}',
             verify_certs=False,
             # ca_certs=settings.config["elastic_ca_cert_path"],
@@ -192,8 +193,8 @@ def _cleanup(
         )
         es.info()
         print("elastic index: ", elastic.elastic_index)
-        resp = es.index(index=elastic.elastic_index, document=testdata.elastic_doc)
-        print(resp["result"])
+        resp = es.index(index=elastic.elastic_index, document=elastic.elastic_doc)
+        print(resp["result"])'''
 
 
 def pytest_configure(config: Config) -> None:
@@ -354,7 +355,7 @@ def pytest_generate_tests(metafunc) -> None:
         metafunc.parametrize("execution_number", range(end))
 
 
-def elastic(settings, testdata):
+def elastic_push(settings, testdata):
     if settings.config["log_performance_elastic"]:
         es = Elasticsearch(
             f'https://{settings.config["elastic_host"]}:{settings.config["elastic_port"]}',
@@ -366,8 +367,11 @@ def elastic(settings, testdata):
             ),
         )
         es.info()
-        print(testdata.index)
-        resp = es.index(index=testdata.index, document=testdata.elastic_doc)
+
+        #elastic.elastic_doc["testdata"] = testdata.to_json()
+        elastic.elastic_doc["settings"] = settings
+
+        resp = es.index(index=elastic.elastic_index, document=elastic.elastic_doc)
         print(resp["result"])
 
 

--- a/sriov/tests/conftest.py
+++ b/sriov/tests/conftest.py
@@ -182,19 +182,6 @@ def _cleanup(
 
     if settings.config["log_performance_elastic"]:
         elastic_push(settings, testdata)
-        '''es = Elasticsearch(
-            f'https://{settings.config["elastic_host"]}:{settings.config["elastic_port"]}',
-            verify_certs=False,
-            # ca_certs=settings.config["elastic_ca_cert_path"],
-            basic_auth=(
-                settings.config["elastic_username"],
-                settings.config["elastic_password"],
-            ),
-        )
-        es.info()
-        print("elastic index: ", elastic.elastic_index)
-        resp = es.index(index=elastic.elastic_index, document=elastic.elastic_doc)
-        print(resp["result"])'''
 
 
 def pytest_configure(config: Config) -> None:
@@ -312,7 +299,7 @@ def _report_extras(extra, request, settings, testdata, monkeypatch) -> None:
                 if git_tag:
                     elastic.elastic_doc["tag"] = str(git_tag)
                 elif sha:
-                    elastic.elastic_doc["tag"] = str(sha)
+                    elastic.elastic_doc["tag"] = str(sha.hexsha)
 
             extra.append(
                 extras.html(
@@ -367,9 +354,6 @@ def elastic_push(settings, testdata):
             ),
         )
         es.info()
-
-        #elastic.elastic_doc["testdata"] = testdata.to_json()
-        elastic.elastic_doc["settings"] = settings
 
         resp = es.index(index=elastic.elastic_index, document=elastic.elastic_doc)
         print(resp["result"])

--- a/sriov/tests/conftest.py
+++ b/sriov/tests/conftest.py
@@ -20,10 +20,12 @@ from sriov.common.utils import (
     execute_and_assert,
 )
 
+
 class elastic:
     # track elastic results (currently used in SR_IOV_Sanity_Performance)
     elastic_index = None
     elastic_doc = {}
+
 
 def get_settings_obj() -> Config:
     script_dir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
An initial commit for the pull of results, tags, and timestamp to elastic for further processing/creating dashboards. This commit represents the beginning of being able to use elastic, not a comprehensive implementation. For this reason if other extensions (such as supporting CA Certs, more fields, etc.) are implemented they will follow in subsequent commits.

For information on the elastic and kibana deployment used for testing, see [this document](https://docs.google.com/document/d/1gOjT4hoc8jhe_G0qhyHFvCeKqrdiWQDGA4RKYCgaFps/edit?usp=sharing)