### PR TITLE
Bump python version to 3.10 for e2e flow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -50,7 +50,7 @@ jobs:
         run: |
           files=`git diff --name-only origin/main`
           echo "diff files: $files"
-          pyfiles="conftest.py config.py configtestdata.py utils.py exec.py macros.py"
+          pyfiles="conftest.py config.py configtestdata.py utils.py exec.py macros.py e2e.yaml"
           mode=""
           tests=()
           for f in ${files}; do

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.10
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Update python version for e2e test and force full e2e CI run in case of changes in e2e.yaml.